### PR TITLE
Handle the situation where you may not be able to decrease process niceness e.g. on an lxc container.

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1131,7 +1131,7 @@ def main(options, rootdir=""):
 
     # FIXME: make this into a ContextManager
     # stop being nice
-    os.nice(old_priority - os.nice(19))
+    os.nice(old_priority - os.nice(0))
 
     # download what looks good
     if options.debug:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -41,6 +41,7 @@ import sys
 
 
 from email.message import Message
+from errno import EACCESS, EPERM
 from gettext import gettext as _
 from io import StringIO
 from optparse import (
@@ -1103,7 +1104,16 @@ def main(options, rootdir=""):
 
     # FIXME: make this into a ContextManager
     # be nice when calculating the upgrade as its pretty CPU intensive
-    os.nice(19)
+    old_priority = os.nice(0)
+    try:
+        # Check that we will be able to restore the priority
+        os.nice(-1)
+        os.nice(20)
+    except OSError as e:
+        if e.errno in (EPERM, EACCESS):
+            pass
+        else:
+            raise
 
     # speed things up with latest apt
     actiongroup = apt_pkg.ActionGroup(cache._depcache)
@@ -1121,7 +1131,7 @@ def main(options, rootdir=""):
 
     # FIXME: make this into a ContextManager
     # stop being nice
-    os.nice(-19)
+    os.nice(old_priority - os.nice(19))
 
     # download what looks good
     if options.debug:


### PR DESCRIPTION
stgraber indicated all his lxc-containers are crashing when running unattended-upgrades because "you can't set negative nice values in an unprivileged LXC container even if you're root inside it", this fixes that by only changing the niceness if we'll be able to restore it.