### PR TITLE
In the apport package hook gather the right log file name.

### DIFF
--- a/debian/source_unattended-upgrades.py
+++ b/debian/source_unattended-upgrades.py
@@ -2,7 +2,7 @@
 unattended-upgrades apport hook
 
 Collects the following log file:
-  - /var/log/unattended-upgrades/unattended-upgrades
+  - /var/log/unattended-upgrades/unattended-upgrades.log
 Check to see if either of these conffiles has been modified:
   - /etc/apt/apt.conf.d/50unattended-upgrades
   - /etc/apt/apt.conf.d/10periodic
@@ -18,4 +18,4 @@ def add_info(report, ui):
     attach_conffiles(report, 'unattended-upgrades', ui=ui)
     attach_conffiles(report, 'update-notifier-common', ui=ui)
     attach_file_if_exists(report,
-                          '/var/log/unattended-upgrades/unattended-upgrades')
+                          '/var/log/unattended-upgrades/unattended-upgrades.log')


### PR DESCRIPTION
I've no idea how this was overlooked, but let's fix it.