### PR TITLE
display translations in proper locale

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -41,7 +41,7 @@ import sys
 
 
 from email.message import Message
-from gettext import gettext as _
+from gettext import lgettext as _
 from io import StringIO
 from optparse import (
     OptionParser,
@@ -1052,7 +1052,7 @@ def main(options, rootdir=""):
     logging.info(_("Starting unattended upgrades script"))
 
     # display available origin
-    logging.info(_("Allowed origins are: %s") % allowed_origins)
+    logging.info(_("Allowed origins are: %s"), allowed_origins)
 
     # check if the journal is dirty and if so, take emergceny action
     # the alternative is to leave the system potentially unsecure until

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -398,8 +398,8 @@ def upgrade_normal(cache, pkgs_to_upgrade, logfile_dpkg, verbose):
         logging.info(_("All upgrades installed"))
     else:
         logging.error(_("Installing the upgrades failed!"))
-        logging.error(_("error message: '%s'") % error)
-        logging.error(_("dpkg returned a error! See '%s' for details") %
+        logging.error(_("error message: '%s'"), error)
+        logging.error(_("dpkg returned a error! See '%s' for details"),
                       logfile_dpkg)
     return res
 
@@ -477,8 +477,8 @@ def upgrade_in_minimal_steps(cache, pkgs_to_upgrade, blacklist,
             if verbose:
                 logging.exception("Exception happened during upgrade.")
             logging.error(_("Installing the upgrades failed!"))
-            logging.error(_("error message: '%s'") % e)
-            logging.error(_("dpkg returned a error! See '%s' for details") %
+            logging.error(_("error message: '%s'"), e)
+            logging.error(_("dpkg returned a error! See '%s' for details"),
                           logfile_dpkg)
             return False
         to_upgrade = to_upgrade - set(smallest_partition)
@@ -813,7 +813,7 @@ def send_summary_mail(pkgs, res, pkgs_kept_back, mem_log, dpkg_log_content):
         raise AssertionError(
             "This should never be reached, if we are here we either "
             "have sendmail or mailx. Please report this as a bug.")
-    logging.debug("mail returned: %s" % ret)
+    logging.debug("mail returned: %s", ret)
 
 
 def do_install(cache, pkgs_to_upgrade, blacklisted_pkgs, whitelisted_pkgs,
@@ -822,7 +822,7 @@ def do_install(cache, pkgs_to_upgrade, blacklisted_pkgs, whitelisted_pkgs,
     os.putenv("DEBIAN_FRONTEND", "noninteractive")
     setup_apt_listchanges()
 
-    logging.info(_("Writing dpkg log to '%s'") % logfile_dpkg)
+    logging.info(_("Writing dpkg log to '%s'"), logfile_dpkg)
 
     marked_delete = [pkg for pkg in cache.get_changes() if pkg.marked_delete]
     if marked_delete:
@@ -978,7 +978,7 @@ def try_to_upgrade(pkg, pkgs_to_upgrade, pkgs_kept_back, cache, allowed_origins,
         # can't upgrade
         logging.warning(
             _("package '%s' upgradable but fails to "
-                "be marked for upgrade (%s)") % (pkg.name, e))
+                "be marked for upgrade (%s)"), pkg.name, e)
         rewind_cache(cache, pkgs_to_upgrade)
         pkgs_kept_back.append(pkg.name)
 
@@ -1133,9 +1133,9 @@ def main(options, rootdir=""):
     try:
         pm.get_archives(fetcher, list, recs)
     except SystemError as e:
-        logging.error(_("GetArchives() failed: '%s'") % e)
+        logging.error(_("GetArchives() failed: '%s'"), e)
     res = fetcher.run()
-    logging.debug("fetch.run() result: %s" % res)
+    logging.debug("fetch.run() result: %s", res)
 
     if dpkg_conffile_prompt():
         # now check the downloaded debs for conffile conflicts and build
@@ -1144,18 +1144,18 @@ def main(options, rootdir=""):
             logging.debug("%s" % item)
             if item.status == item.STAT_ERROR:
                 print(_("An error occurred: '%s'") % item.error_text)
-                logging.error(_("An error occurred: '%s'") % item.error_text)
+                logging.error(_("An error occurred: '%s'"), item.error_text)
             if not item.complete:
                 print(_("The URI '%s' failed to download, aborting") %
                       item.desc_uri)
-                logging.error(_("The URI '%s' failed to download, aborting") %
+                logging.error(_("The URI '%s' failed to download, aborting"),
                               item.desc_uri)
                 sys.exit(1)
             if not os.path.exists(item.destfile):
                 print(_("Download finished, but file '%s' not there?!?" %
                         item.destfile))
                 logging.error("Download finished, but file '%s' not "
-                              "there?!?" % item.destfile)
+                              "there?!?", item.destfile)
                 sys.exit(1)
             if not item.is_trusted:
                 blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
@@ -1173,7 +1173,7 @@ def main(options, rootdir=""):
                           pkgname_from_deb(item.destfile))
                 # log to the logfile
                 logging.warning(_("Package '%s' has conffile prompt and "
-                                  "needs to be upgraded manually") %
+                                  "needs to be upgraded manually"),
                                 pkgname_from_deb(item.destfile))
                 blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
                 pkgs_kept_back.append(pkgname_from_deb(item.destfile))
@@ -1198,7 +1198,7 @@ def main(options, rootdir=""):
                 else:
                     if not (pkg.name in pkgs_kept_back):
                         pkgs_kept_back.append(pkg.name)
-                    logging.info(_("package '%s' not upgraded") % pkg.name)
+                    logging.info(_("package '%s' not upgraded"), pkg.name)
                     cache.clear()
                     for pkg2 in pkgs_to_upgrade:
                         pkg2.mark_upgrade()
@@ -1213,12 +1213,12 @@ def main(options, rootdir=""):
         for pkgname in now_auto_removable - pkgs_auto_removable:
             logging.debug("marking %s for remove" % pkgname)
             cache[pkgname].mark_delete()
-        logging.info(_("Packages that are auto removed: '%s'") %
+        logging.info(_("Packages that are auto removed: '%s'"),
                      " ".join(now_auto_removable - pkgs_auto_removable))
 
-    logging.debug("InstCount=%i DelCount=%i BrokenCount=%i" % (
+    logging.debug("InstCount=%i DelCount=%i BrokenCount=%i",
         cache._depcache.inst_count, cache._depcache.del_count,
-        cache._depcache.broken_count))
+        cache._depcache.broken_count)
 
     # exit if there is nothing to do and nothing to report
     if (len(pkgs_to_upgrade) == 0) and (len(pkgs_kept_back) == 0):
@@ -1244,7 +1244,7 @@ def main(options, rootdir=""):
 
     # do the install based on the new list of pkgs
     pkgs = " ".join([pkg.name for pkg in pkgs_to_upgrade])
-    logging.info(_("Packages that will be upgraded: %s" % pkgs))
+    logging.info(_("Packages that will be upgraded: %s", pkgs))
 
     # get log
     logfile_dpkg = os.path.join(_get_logdir(), 'unattended-upgrades-dpkg.log')

--- a/unattended-upgrade-shutdown
+++ b/unattended-upgrade-shutdown
@@ -150,7 +150,7 @@ if __name__ == "__main__":
         log_progress()
         time.sleep(5)
         if (time.time() - start_time) > options.delay * 60:
-            logging.warning(_("Giving up on lockfile after %s delay") %
+            logging.warning(_("Giving up on lockfile after %s delay"),
                             options.delay)
             sys.exit(1)
 


### PR DESCRIPTION
without this, translations would get encoded using the ascii codec
which would break with an infamous UnicodeEncodeError exception. by
using lgettext(), the proper encoding is automatically chosen on
output which seems to be a good practice here.

notice that i had to change from the string formatting operator to
arguments to the logging function in a specific case, otherwise i
would get the following exception:

TypeError: unsupported operand type(s) for %: 'bytes' and 'list'

This is a weird Python 3 specific exception, but it makes sense: the
string is encoded to bytes already and the formatting operator doesn't
want to take any chances. the proper way to fix this is to use the
builtin formatting of the logging function. i have done this in the
one place where i still had, but it's possible that i missed other possible places.