### PR TITLE
auto-remove: don't print a message with empty list of pkg

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1088,6 +1088,8 @@ def get_auto_removable(cache):
 
 def do_auto_remove(cache, options, logfile_dpkg, verbose=False):
     auto_removable = get_auto_removable(cache)
+    if not auto_removable:
+        return True
 
     for pkgname in auto_removable:
         logging.debug("marking %s for remove" % pkgname)


### PR DESCRIPTION
this bug happens only were there is something to upgrade but nothing to auto-remove.

```
2015-06-28 09:20:22,374 INFO Packages that will be upgraded: binutils gcc-5-base gcc-5-base:i386 libevdev2 libgcc1 libgcc1:i386 libgfortran3 libgomp1 libmpfr4 libquadmath0 libstdc++6 libstdc++6:i386 libwxbase3.0-0 libwxgtk3.0-0 w3m
2015-06-28 09:20:22,376 INFO Écriture du journal de dpkg dans « /var/log/unattended-upgrades/unattended-upgrades-dpkg.log »
2015-06-28 09:21:23,903 INFO Toutes les mises à niveau ont été installées
2015-06-28 09:21:39,565 INFO Suppression automatique des paquets : 
2015-06-28 09:21:39,691 INFO Packages were successfully auto-removed
```