### PR TITLE
Add [package on hold] to mail subject

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -806,13 +806,14 @@ def send_summary_mail(pkgs, res, pkgs_kept_back, mem_log, dpkg_log_content):
         return
     # Check if reboot-required flag is present
     logging.debug("Sending mail to '%s'" % to_email)
+    subject = _("unattended-upgrades result for '%s': %s") % (host(), res)
+    flags = ""
     if os.path.isfile(REBOOT_REQUIRED_FILE):
-        subject = _(
-            "[reboot required] unattended-upgrades result for '%s': %s") % (
-            host(), res)
-    else:
-        subject = _("unattended-upgrades result for '%s': '%s'") % (
-            host(), res)
+        flags += _("[reboot required]")
+    if pkgs_kept_back:
+        flags += _("[package on hold]")
+    if flags:
+        subject = flags + " " + subject
     body = _("Unattended upgrade returned: %s\n\n") % res
     if os.path.isfile(REBOOT_REQUIRED_FILE):
         body += _(

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -805,15 +805,16 @@ def send_summary_mail(pkgs, res, pkgs_kept_back, mem_log, dpkg_log_content):
             "Unattended-Upgrade::MailOnlyOnError", False)):
         return
     # Check if reboot-required flag is present
+    reboot_flag_str = _(
+        "[reboot required]") if os.path.isfile(REBOOT_REQUIRED_FILE) else ""
+    # Check if packages are kept on hold
+    hold_flag_str = _("[package on hold]") if pkgs_kept_back else ""
     logging.debug("Sending mail to '%s'" % to_email)
-    subject = _("unattended-upgrades result for '%s': %s") % (host(), res)
-    flags = ""
-    if os.path.isfile(REBOOT_REQUIRED_FILE):
-        flags += _("[reboot required]")
-    if pkgs_kept_back:
-        flags += _("[package on hold]")
-    if flags:
-        subject = flags + " " + subject
+    subject = _(
+        "{hold_flag}{reboot_flag} unattended-upgrades result for "
+        "'{machine}': {result}").format(
+            hold_flag=hold_flag_str, reboot_flag=reboot_flag_str,
+            machine=host(), result=res).strip()
     body = _("Unattended upgrade returned: %s\n\n") % res
     if os.path.isfile(REBOOT_REQUIRED_FILE):
         body += _(


### PR DESCRIPTION
This PR adds a [package on hold] "flag" in the mail subject to catch attention, just like already existing [reboot required].

The rationale is that an admin may want to get all emails but only read those that need manual action.

See my comment [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=625847#35).

Feel free to ask for a rework if you like the idea but not the implementation.

Note that this change removes string

    msgid "[reboot required] unattended-upgrades result for '%s'"

and adds

    msgid "[reboot required]"
    msgid "[package on hold]"

the first can be easily stripped from existing translation file, so no real regression here.