### PR TITLE
Speed up sanity check by filtering cache.

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -521,7 +521,7 @@ def is_pkgname_in_whitelist(pkgname, whitelist):
 def check_changes_for_sanity(cache, allowed_origins, blacklist, whitelist):
     if cache._depcache.broken_count != 0:
         return False
-    for pkg in cache:
+    for pkg in cache.get_changes():
         if pkg.marked_delete:
             logging.debug("pkg '%s' now marked delete" % pkg.name)
             return False


### PR DESCRIPTION
The apt.cache.Cache.get_changes() method returns only packages that are not marked as keep. The sanity check does not care for packages that are marked as keep, so it seems to make sense to filter the cache first to avoid unneeded loops.

On a test system with 140 upgradeable packages, this reduced the runtime of unattended-upgrade from 4m32s to 1m5s (without installation of packages).