### PR TITLE
Allow to configure sender email for sendmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ Supported Options Reference
  Unattended-Upgrade::Mail "user@example.com";
  ```
 
+* `Unattended-Upgrade::Sender` - string (default:"root")
+
+ Use the specified value in the "From" field of outgoing mails.
+ 
+  Example:
+ ```
+ Unattended-Upgrade::Sender "server@example.com";
+ ```
+
 * `Unattended-Upgrade::MailOnlyOnError` - boolean (default:False)
  
  Only generate a email if some problem occured during the 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -766,10 +766,11 @@ def _send_mail_using_mailx(to_address, subject, body):
     return ret
 
 
-def _send_mail_using_sendmail(to_address, subject, body):
+def _send_mail_using_sendmail(from_address, to_address, subject, body):
     # format as a proper mail
     msg = Message()
     msg['Subject'] = subject
+    msg['From'] = from_address
     msg['To'] = to_address
     # order is important here, Message() first, then Charset()
     #  then msg.set_charset()
@@ -837,8 +838,10 @@ def send_summary_mail(pkgs, res, pkgs_kept_back, mem_log, dpkg_log_content):
     body += _("Unattended-upgrades log:\n")
     body += mem_log.getvalue()
 
+    from_email = apt_pkg.config.find("Unattended-Upgrade::Sender", "root")
+
     if os.path.exists(SENDMAIL_BINARY):
-        ret = _send_mail_using_sendmail(to_email, subject, body)
+        ret = _send_mail_using_sendmail(from_email, to_email, subject, body)
     elif os.path.exists(MAIL_BINARY):
         ret = _send_mail_using_mailx(to_email, subject, body)
     else:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -749,7 +749,7 @@ def setup_apt_listchanges(conf="/etc/apt/listchanges.conf"):
         os.environ["APT_LISTCHANGES_FRONTEND"] = "none"
 
 
-def _send_mail_using_mailx(to_address, subject, body):
+def _send_mail_using_mailx(from_address, to_address, subject, body):
     # ensure that the body is a byte stream and that we do not
     # break on encoding errors (the default error mode is "strict")
     encoded_body = body.encode(
@@ -758,7 +758,7 @@ def _send_mail_using_mailx(to_address, subject, body):
     # unicode encoding errors (e.g. because the user is running a
     # ascii only system like the buildds)
     mail = subprocess.Popen(
-        [MAIL_BINARY, "-s", subject, to_address],
+        [MAIL_BINARY, "-r", from_address, "-s", subject, to_address],
         stdin=subprocess.PIPE, universal_newlines=False)
     mail.stdin.write(encoded_body)
     mail.stdin.close()
@@ -843,7 +843,7 @@ def send_summary_mail(pkgs, res, pkgs_kept_back, mem_log, dpkg_log_content):
     if os.path.exists(SENDMAIL_BINARY):
         ret = _send_mail_using_sendmail(from_email, to_email, subject, body)
     elif os.path.exists(MAIL_BINARY):
-        ret = _send_mail_using_mailx(to_email, subject, body)
+        ret = _send_mail_using_mailx(from_email, to_email, subject, body)
     else:
         raise AssertionError(
             "This should never be reached, if we are here we either "


### PR DESCRIPTION
This allows to specify the email address of the sender. At least when using sendmail.

I needed this as I use kuvert to sign and encrypt outgoing mails. Kuvert requieres that the from field of the email is set.