### PR TITLE
Minor documentation typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ every day.
 
 The main way to specify which packages will be auto-upgraded is by
 means of their "origin" and "archive".  These are taken respectively
-from the Origin and Suite fields of the respository's Release file,
+from the Origin and Suite fields of the repository's Release file,
 or can be found in the output of:
 ```
 $ apt-cache policy

--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -7,7 +7,7 @@
 // keywords are wild cards.) The keywords originate from the Release
 // file, but several aliases are accepted.  The accepted keywords are:
 //   a,archive,suite (eg, "stable")
-//   c,component     (eg, "main", "crontrib", "non-free")
+//   c,component     (eg, "main", "contrib", "non-free")
 //   l,label         (eg, "Debian", "Debian-Security")
 //   o,origin        (eg, "Debian", "Unofficial Multimedia Packages")
 //   n,codename      (eg, "jessie", "jessie-updates")

--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -7,7 +7,7 @@
 // keywords are wild cards.) The keywords originate from the Release
 // file, but several aliases are accepted.  The accepted keywords are:
 //   a,archive,suite (eg, "stable")
-//   c,component     (eg, "main", "crontrib", "non-free")
+//   c,component     (eg, "main", "contrib", "non-free")
 //   l,label         (eg, "Rapsbian", "Raspbian-Security")
 //   o,origin        (eg, "Raspbian", "Unofficial Multimedia Packages")
 //   n,codename      (eg, "jessie", "jessie-updates")


### PR DESCRIPTION
Fixes for a few typos in configs and readme I noticed while installing and setting up the package.