### PR TITLE
Feature/patch day

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,5 +249,18 @@ Supported Options Reference
  Note that unattended-upgrades detects this options and ensures that
  packages with configuration prompts will never be held back.
 
+* `Unattended-Upgrade::Update-Days` - list of strings (default:empty)
+
+ Set the days of the week that updates should be applied.
+
+ Example - apply updates only on Monday and Friday
+ ```
+ Unattended-Upgrade::Update-Days {"Mon","Fri"};
+ ```
+ The default is an empty list which means updates are applied every day.
+
+
+
+
 [travis-image]: https://travis-ci.org/mvo5/unattended-upgrades.svg?branch=debian/sid
 [travis-url]: https://travis-ci.org/mvo5/unattended-upgrades

--- a/README.md
+++ b/README.md
@@ -251,7 +251,9 @@ Supported Options Reference
 
 * `Unattended-Upgrade::Update-Days` - list of strings (default:empty)
 
- Set the days of the week that updates should be applied.
+ Set the days of the week that updates should be applied. The days
+ can be specified as localized abbreviated or full names. Or as
+ integers where "0" is Sunday, "1" is Monday etc.
 
  Example - apply updates only on Monday and Friday
  ```

--- a/test/test_patch_days.py
+++ b/test/test_patch_days.py
@@ -8,7 +8,11 @@ import apt
 
 import unattended_upgrade
 
+
 class TestUpdateDays(unittest.TestCase):
+
+    def setUp(self):
+        apt.apt_pkg.config.clear("Unattended-Upgrade::Update-Days")
 
     def test_update_days_no_patch_days_always_runs_uu(self):
         apt.apt_pkg.config.clear("Unattended-Upgrade::Update-Days")
@@ -44,7 +48,6 @@ class TestUpdateDays(unittest.TestCase):
         # that was a Sun
         mock_date.today.return_value = date(2007, 7, 29)
         self.assertTrue(unattended_upgrade.is_update_day())
-
 
 
 if __name__ == "__main__":

--- a/test/test_patch_days.py
+++ b/test/test_patch_days.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+
+from datetime import date
+import unittest
+from mock import patch
+
+import apt
+
+import unattended_upgrade
+
+class TestUpdateDays(unittest.TestCase):
+
+    def test_update_days_no_patch_days_always_runs_uu(self):
+        apt.apt_pkg.config.clear("Unattended-Upgrade::Update-Days")
+        self.assertTrue(unattended_upgrade.is_update_day())
+
+    @patch("unattended_upgrade.date")
+    def test_update_days_by_name(self, mock_date):
+        mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "Wed")
+        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "Sun")
+        # that was a Wed
+        mock_date.today.return_value = date(2007, 8, 22)
+        self.assertTrue(unattended_upgrade.is_update_day())
+        # that was a Th
+        mock_date.today.return_value = date(2007, 8, 2)
+        self.assertFalse(unattended_upgrade.is_update_day())
+        # that was a Sun
+        mock_date.today.return_value = date(2007, 7, 29)
+        self.assertTrue(unattended_upgrade.is_update_day())
+
+    @patch("unattended_upgrade.date")
+    def test_update_days_by_number(self, mock_date):
+        mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+        # 0: Mon, 1: Tue, ...
+        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "2")
+        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "6")
+        # that was a Wed
+        mock_date.today.return_value = date(2007, 8, 22)
+        self.assertTrue(unattended_upgrade.is_update_day())
+        # that was a Thu
+        mock_date.today.return_value = date(2007, 8, 2)
+        self.assertFalse(unattended_upgrade.is_update_day())
+        # that was a Sun
+        mock_date.today.return_value = date(2007, 7, 29)
+        self.assertTrue(unattended_upgrade.is_update_day())
+
+    def test_update_days_validation(self):
+        # an invalid setting makes every day a patch day 
+        # (err on the safe side)
+        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "invalid")
+        self.assertTrue(unattended_upgrade.is_update_day())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_patch_days.py
+++ b/test/test_patch_days.py
@@ -32,9 +32,9 @@ class TestUpdateDays(unittest.TestCase):
     @patch("unattended_upgrade.date")
     def test_update_days_by_number(self, mock_date):
         mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
-        # 0: Mon, 1: Tue, ...
-        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "2")
-        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "6")
+        # 0: Sun, 1: Mon, ...
+        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "3")
+        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "0")
         # that was a Wed
         mock_date.today.return_value = date(2007, 8, 22)
         self.assertTrue(unattended_upgrade.is_update_day())
@@ -45,11 +45,6 @@ class TestUpdateDays(unittest.TestCase):
         mock_date.today.return_value = date(2007, 7, 29)
         self.assertTrue(unattended_upgrade.is_update_day())
 
-    def test_update_days_validation(self):
-        # an invalid setting makes every day a patch day 
-        # (err on the safe side)
-        apt.apt_pkg.config.set("Unattended-Upgrade::Update-Days::", "invalid")
-        self.assertTrue(unattended_upgrade.is_update_day())
 
 
 if __name__ == "__main__":

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1142,8 +1142,11 @@ def is_update_day():
     # by number (Sun: 0, Mon: 1, ...)
     if today.strftime("%w") in patch_days:
         return True
-    # not found
-    logging.info("Skipping update check: today is '%s' but patch days are '%s'", today.strftime("%A"), patch_days)
+    # today is not a patch day
+    logging.info(
+        "Skipping update check: today is '%s,%s,%s' but patch days are '%s'",
+        today.strftime("%w"), today.strftime("%a"), today.strftime("%A"),
+        patch_days)
     return False
 
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -41,6 +41,7 @@ import subprocess
 import sys
 
 
+from datetime import date
 from email.message import Message
 from gettext import gettext as _
 from io import StringIO
@@ -1125,6 +1126,50 @@ def clean_downloaded_packages(fetcher):
                 pass
 
 
+def is_update_day():
+    weekday_map = {
+        # by num
+        '0': 0,
+        '1': 1,
+        '2': 2,
+        '3': 3,
+        '4': 4,
+        '5': 5,
+        '6': 6,
+        # abbrev
+        'Mon': 0,
+        'Tue': 1,
+        'Wed': 2,
+        'Thu': 3,
+        'Fri': 4,
+        'Sat': 5,
+        'Sun': 6,
+        # long
+        'Monday': 0,
+        'Tuesday': 1,
+        'Wednesday': 2,
+        'Thursday': 3,
+        'Friday': 4,
+        'Saturday': 5,
+        'Sunday': 6,
+    }
+    # if the user has nothing configured always run
+    patch_days = apt_pkg.config.value_list("Unattended-Upgrade::Update-Days")
+    if not patch_days:
+        return True
+    # validate patch days
+    for v in patch_days:
+        if v not in weekday_map:
+            logging.error("invalid udpate day '%s', ignoring the Update-Days config", v)
+            return True
+    # check if today is a patch day
+    today = date.today()
+    if today.weekday() in [weekday_map.get(name) for name in patch_days]:
+        return True
+    logging.info("Skipping update check: today is '%s' but patch days are '%s'", today.strftime("%A"), patch_days)
+    return False
+
+
 def main(options, rootdir=""):
     # useful for testing
     if rootdir:
@@ -1132,6 +1177,10 @@ def main(options, rootdir=""):
 
     # setup logging
     mem_log = _setup_logging(options)
+
+    # check if today is a patch day
+    if not is_update_day():
+        return
 
     # format (origin, archive), e.g. ("Ubuntu","dapper-security")
     allowed_origins = get_allowed_origins()

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1127,45 +1127,22 @@ def clean_downloaded_packages(fetcher):
 
 
 def is_update_day():
-    weekday_map = {
-        # by num
-        '0': 0,
-        '1': 1,
-        '2': 2,
-        '3': 3,
-        '4': 4,
-        '5': 5,
-        '6': 6,
-        # abbrev
-        'Mon': 0,
-        'Tue': 1,
-        'Wed': 2,
-        'Thu': 3,
-        'Fri': 4,
-        'Sat': 5,
-        'Sun': 6,
-        # long
-        'Monday': 0,
-        'Tuesday': 1,
-        'Wednesday': 2,
-        'Thursday': 3,
-        'Friday': 4,
-        'Saturday': 5,
-        'Sunday': 6,
-    }
-    # if the user has nothing configured always run
+    # check if patch days are configured
     patch_days = apt_pkg.config.value_list("Unattended-Upgrade::Update-Days")
     if not patch_days:
         return True
     # validate patch days
-    for v in patch_days:
-        if v not in weekday_map:
-            logging.error("invalid udpate day '%s', ignoring the Update-Days config", v)
-            return True
-    # check if today is a patch day
     today = date.today()
-    if today.weekday() in [weekday_map.get(name) for name in patch_days]:
+    # abbreviated localized dayname
+    if today.strftime("%a") in patch_days:
         return True
+    # full localized dayname
+    if today.strftime("%A") in patch_days:
+        return True
+    # by number (Sun: 0, Mon: 1, ...)
+    if today.strftime("%w") in patch_days:
+        return True
+    # not found
     logging.info("Skipping update check: today is '%s' but patch days are '%s'", today.strftime("%A"), patch_days)
     return False
 


### PR DESCRIPTION
Add configuration to allow to specify at which days of the week updates should be applied. This makes it easier to spread out updates in larger installations to ensure that a single faulty update does not kill all machines at once.