### PR TITLE
enable escaped colons in Unattended-Upgrade::Allowed-Origins

### DIFF
--- a/test/data/50unattended-upgrades.colon
+++ b/test/data/50unattended-upgrades.colon
@@ -1,0 +1,4 @@
+// Automatically upgrade packages from these (origin:archive) pairs
+Unattended-Upgrade::Allowed-Origins {
+        "http\://foo.bar:stable";
+};

--- a/test/test_origin_pattern.py
+++ b/test/test_origin_pattern.py
@@ -96,6 +96,14 @@ class TestOriginPatern(unittest.TestCase):
         pkg = self._get_mock_package()
         self.assertTrue(is_allowed_origin(pkg.candidate, allowed_origins))
 
+    def test_escaped_colon(self):
+        apt_pkg.config.clear("Unattended-Upgrade")
+        apt_pkg.read_config_file(
+            apt_pkg.config, "./data/50unattended-upgrades.colon")
+        allowed_origins = unattended_upgrade.get_allowed_origins()
+
+        self.assertIn('o=http://foo.bar,a=stable', allowed_origins)
+
     def test_unkown_matcher(self):
         apt_pkg.config.clear("Unattended-Upgrade")
         s = "xxx=OriginUbuntu"

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -325,7 +325,8 @@ def get_allowed_origins_legacy():
         if ":" in s:
             # don't handle escaped colons '\:' as separator. Only plain colon
             # but replace escaped colons with plain colons when done splitting
-            (distro_id, distro_codename) = [re.sub(r'\\:', ':', x) for x in re.split(r'(?<!\\):', s)]
+            (distro_id, distro_codename) = [re.sub(r'\\:', ':', x)
+                                            for x in re.split(r'(?<!\\):', s)]
         else:
             (distro_id, distro_codename) = s.split()
         # escape "," (see LP: #824856) - i wonder if there is a simpler way?

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -323,7 +323,9 @@ def get_allowed_origins_legacy():
     for s in apt_pkg.config.value_list("Unattended-Upgrade::Allowed-Origins"):
         # if there is a ":" use that as seperator, else use spaces
         if ":" in s:
-            (distro_id, distro_codename) = s.split(':')
+            # don't handle escaped colons '\:' as separator. Only plain colon
+            # but replace escaped colons with plain colons when done splitting
+            (distro_id, distro_codename) = [re.sub(r'\\:', ':', x) for x in re.split(r'(?<!\\):', s)]
         else:
             (distro_id, distro_codename) = s.split()
         # escape "," (see LP: #824856) - i wonder if there is a simpler way?


### PR DESCRIPTION
This PR will enable escaped colons in Unattended-Upgrade::Allowed-Origins

Origins can have colons e.g. 'obs://build.opensuse.org/isv:ownCloud:desktop/Ubuntu_16.04'
