### PR TITLE
Update 50unattended-upgrades.Ubuntu

### DIFF
--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -1,5 +1,6 @@
 // Automatically upgrade packages from these (origin:archive) pairs
 Unattended-Upgrade::Allowed-Origins {
+        "${distro_id}:${distro_codename}";
 	"${distro_id}:${distro_codename}-security";
 //	"${distro_id}:${distro_codename}-updates";
 //	"${distro_id}:${distro_codename}-proposed";


### PR DESCRIPTION
Modify data/50unattended-upgrades.Ubuntu such that the release pocket is an allowed origin so that security updates with a new dependency will be upgraded and the new dependency will be installed.  This fixes Launchpad bug 1624641 and is being used in Ubuntu 16.04 and 16.10.