### PR TITLE
Create logfile_dpkg if it doesn't exist

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1418,6 +1418,9 @@ def main(options, rootdir=""):
 
     # get log
     logfile_dpkg = os.path.join(_get_logdir(), 'unattended-upgrades-dpkg.log')
+    if not os.path.exists(logfile_dpkg):
+        with open(logfile_dpkg, 'w'):
+            pass
 
     # only perform install step if we actually have packages to install
     pkg_install_success = True


### PR DESCRIPTION
The reading of logfile_dpkg will crash if the file doesn't exist e.g.:

bdmurray@clean-xenial-amd64:~$ sudo /usr/bin/unattended-upgrade
Traceback (most recent call last):
  File "/usr/bin/unattended-upgrade", line 1468, in <module>
    main(options)
  File "/usr/bin/unattended-upgrade", line 1406, in main
    log_content = get_dpkg_log_content(logfile_dpkg, install_start_time)
  File "/usr/bin/unattended-upgrade", line 1075, in get_dpkg_log_content
    with io.open(logfile_dpkg, encoding='utf-8') as fp:
FileNotFoundError: [Errno 2] No such file or directory: '/var/log/unattended-upgrades/unattended-upgrades-dpkg.log'

I figured creating it right away was better than checking for the file existence in get_dpkg_log_content and encountering a crash somewhere else.  This fixes Launchpad bug 1590321.