### PR TITLE
Make sure the statedir exists too

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1043,6 +1043,8 @@ def reboot_if_requested_and_needed(shutdown_lock=0):
 
 def write_stamp_file():
     statedir = os.path.join(apt_pkg.config.find_dir("Dir::State"), "periodic")
+    if not os.path.exists(statedir):
+        os.makedirs(statedir)
     with open(os.path.join(statedir, "unattended-upgrades-stamp"), "w"):
         pass
 


### PR DESCRIPTION
This fixes Launchpad bug 1639977 with the following Traceback:

Traceback (most recent call last):
  File "/usr/bin/unattended-upgrade", line 1468, in <module>
    main(options)
  File "/usr/bin/unattended-upgrade", line 1331, in main
    write_stamp_file()
  File "/usr/bin/unattended-upgrade", line 1011, in write_stamp_file
    with open(os.path.join(statedir, "unattended-upgrades-stamp"), "w"):
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/apt/periodic/unattended-upgrades-stamp'