### PR TITLE
ensure network and local-fs are available

### DIFF
--- a/debian/unattended-upgrades.service
+++ b/debian/unattended-upgrades.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Unattended Upgrades Shutdown
 DefaultDependencies=no
-Before=shutdown.target reboot.target halt.target
+Before=shutdown.target reboot.target halt.target network.target local-fs.target
 Documentation=man:unattended-upgrade(8)
 
 [Service]


### PR DESCRIPTION
For packages to be updated on shutdown unattended-upgrades needs access to the network and local-fs see https://bugs.launchpad.net/ubuntu/+source/unattended-upgrades/+bug/1618900