### PR TITLE
Add in apt history log

### DIFF
--- a/debian/source_unattended-upgrades.py
+++ b/debian/source_unattended-upgrades.py
@@ -19,3 +19,5 @@ def add_info(report, ui):
     attach_conffiles(report, 'update-notifier-common', ui=ui)
     attach_file_if_exists(
         report, '/var/log/unattended-upgrades/unattended-upgrades.log')
+    attach_file_if_exists(
+        report, '/var/log/apt/history.log')


### PR DESCRIPTION
The actual actions happen in /var/log/apt/history.log e.g.:

Start-Date: 2016-12-20  07:42:53
Commandline: /usr/bin/unattended-upgrade
Remove: libspeechd2:amd64 (0.8.3-1ubuntu3)
End-Date: 2016-12-20  07:43:03