### PR TITLE
Do not mark packages for deletion if using --dry-run

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+unattended-upgrades (0.93.2) UNRELEASED; urgency=medium
+
+  * Do not mark packages for deletion / autoremoval if unattended-upgrades is
+    being run in dry-run mode. (LP: #1544942)
+
+ -- Brian Murray <brian@ubuntu.com>  Wed, 04 Jan 2017 08:47:09 -0800
+
 unattended-upgrades (0.93.1) unstable; urgency=medium
 
   [ Brian Murray ]

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1131,13 +1131,15 @@ def get_auto_removable(cache):
                 if pkg.is_auto_removable])
 
 
-def do_auto_remove(cache, auto_removable, logfile_dpkg, verbose=False):
+def do_auto_remove(cache, auto_removable, logfile_dpkg,
+                   verbose=False, dry_run=False):
     if not auto_removable:
         return True
 
     for pkgname in auto_removable:
-        logging.debug("marking %s for remove" % pkgname)
-        cache[pkgname].mark_delete()
+        if not dry_run:
+            logging.debug("marking %s for remove" % pkgname)
+            cache[pkgname].mark_delete()
     logging.info(_("Packages that are auto removed: '%s'"),
                  " ".join(sorted(auto_removable)))
 
@@ -1455,7 +1457,8 @@ def main(options, rootdir=""):
         auto_removals = get_auto_removable(cache)
         pkg_install_success &= do_auto_remove(
             cache, auto_removals, logfile_dpkg,
-            options.verbose or options.debug)
+            options.verbose or options.debug,
+            options.dry_run)
     # the user wants *only new* auto-removals to be removed
     elif apt_pkg.config.find_b(
             "Unattended-Upgrade::Remove-New-Unused-Dependencies", True):
@@ -1464,7 +1467,8 @@ def main(options, rootdir=""):
         auto_removals = new_pending_autoremovals - previous_autoremovals
         pkg_install_success &= do_auto_remove(
             cache, auto_removals, logfile_dpkg,
-            options.verbose or options.debug)
+            options.verbose or options.debug,
+            options.dry_run)
 
     logging.debug("InstCount=%i DelCount=%i BrokenCount=%i"
                   % (cache._depcache.inst_count,


### PR DESCRIPTION
This fixes a bug reported in Launchpad.  I tried really, really hard to write a test case for this but from what I could tell TestRemoveUnused is not idempotent and running my new test by itself would pass but some others would fail.  I set it up to run the failing ones by themselves and they'd pass.  I think putting the new test in a separate class worked but that seemed terrible.  Anyway, I couldn't figure it out and have been sitting on this for a couple of months.  Now, I figure its better to just get the bug fixed.