### PR TITLE
improve the changes sanity check to cache more insane cases

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+unattended-upgrades (0.93.2) UNRELEASED; urgency=medium
+
+  * When performing a sanity check for packages to install or upgrade return
+    false when either there are no packages in the cache or the package to
+    upgrade is not in the change set. (LP: #1654070)
+
+ -- Brian Murray <brian@ubuntu.com>  Fri, 06 Jan 2017 13:00:24 -0800
+
 unattended-upgrades (0.93.1) unstable; urgency=medium
 
   [ Brian Murray ]

--- a/test/test_origin_pattern.py
+++ b/test/test_origin_pattern.py
@@ -148,6 +148,7 @@ class TestOriginPatern(unittest.TestCase):
         cache = MockCache()
         cache._depcache = MockDepCache()
         cache._depcache.broken_count = 0
+        cache.install_count = 1
         return cache
 
     def _get_mock_origin(self, aorigin="", label="", archive="",

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -552,8 +552,12 @@ def is_pkgname_in_whitelist(pkgname, whitelist):
     return False
 
 
-def check_changes_for_sanity(cache, allowed_origins, blacklist, whitelist):
+def check_changes_for_sanity(cache, allowed_origins, blacklist, whitelist,
+                             desired_pkg=None):
     if cache._depcache.broken_count != 0:
+        return False
+    # If there are no packages to be installed they were kept back
+    if cache.install_count == 0:
         return False
     for pkg in cache:
         if pkg.marked_delete:
@@ -596,6 +600,9 @@ def check_changes_for_sanity(cache, allowed_origins, blacklist, whitelist):
                 logging.debug("pkg '%s' requires app-restart, not safe to "
                               "upgrade unattended")
                 return False
+    # check that the package we want to upgrade is in the change set
+    if desired_pkg and desired_pkg not in cache.get_changes():
+        return False
     return True
 
 
@@ -1057,7 +1064,8 @@ def try_to_upgrade(pkg, pkgs_to_upgrade, pkgs_kept_back, cache,
     try:
         pkg.mark_upgrade(from_user=not pkg.is_auto_installed)
         if check_changes_for_sanity(cache, allowed_origins,
-                                    blacklisted_pkgs, whitelisted_pkgs):
+                                    blacklisted_pkgs, whitelisted_pkgs,
+                                    pkg):
             # add to packages to upgrade
             pkgs_to_upgrade.append(pkg)
             # re-eval pkgs_kept_back as the resolver may fail to
@@ -1283,7 +1291,7 @@ def main(options, rootdir=""):
     actiongroup = apt_pkg.ActionGroup(cache._depcache)
     actiongroup  # pyflakes
 
-    # find out about the packages that are upgradable (in a allowed_origin)
+    # find out about the packages that are upgradable (in an allowed_origin)
     pkgs_to_upgrade, pkgs_kept_back = calculate_upgradable_pkgs(
         cache, options, allowed_origins, blacklisted_pkgs, whitelisted_pkgs)
     pkgs_to_upgrade.sort(key=lambda p: p.name)


### PR DESCRIPTION
This is pretty well detailed in https://bugs.launchpad.net/ubuntu/+source/unattended-upgrades/+bug/1654070 but for some reason the new version of libpulse0 is out of date in my cache and subsequently pulseaudio-module-gconf (which depends on libpulse0) won't update.  However, I kept getting emails that the package was being upgraded, even though it wasn't, and decided to find why.