### PR TITLE
Fix --delay type in unattended-upgrade-shutdown

### DIFF
--- a/unattended-upgrade-shutdown
+++ b/unattended-upgrade-shutdown
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     parser.add_option("", "--debug",
                       action="store_true", dest="debug", default=False,
                       help="print debug messages")
-    parser.add_option("", "--delay", default=10,
+    parser.add_option("", "--delay", default=10, type="int",
                       help="delay in minutes to wait for unattended-upgrades")
     parser.add_option("", "--lock-file",
                       default="/var/run/unattended-upgrades.lock",


### PR DESCRIPTION
delay value is returned as a string which makes the calculation
fail (Closes: #46)

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>