### PR TITLE
Run the init script on more than just shutdown.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -28,8 +28,3 @@ override_dh_auto_clean:
 		rm -f $$f.py; \
 	done
 	$(PYTHON) setup.py clean -a
-
-override_dh_installinit:
-	# we do not want to run the init script in the postinst/prerm, its
-	#  really only useful on shutdown, see Debian bug #645919
-	dh_installinit $@ --no-start -- stop 10 0 6 .


### PR DESCRIPTION
The init script is ueful in more cases than just shutdown, for example
when dpkg-reconfigure is invoked. Doing so after making debconf changes
fails to apply without this commit's modification to debian/rules.

This fixes [LP: #1606600](https://bugs.launchpad.net/ubuntu/+source/unattended-upgrades/+bug/1606600)

This fix might not be minimal (there might be a narrower case in which the linked bug is fixed), but this fix resets the default dh behaviour, so it at least minimizes the unexpected :)

Minimal test case to reproduce the problem this solves (Ubuntu Xenial is assumed):

```bash
sudo su
debconf-show unattended-upgrades  # shows "unattended-upgrades/enable_auto_updates: true"
echo "debconf unattended-upgrades/enable_auto_updates boolean false" | debconf-set-selections -
debconf-show unattended-upgrades  # shows "unattended-upgrades/enable_auto_updates: false"
dpkg-reconfigure -fnoninteractive unattended-upgrades
debconf-show unattended-upgrades # shows "unattended-upgrades/enable_auto_updates: true" again.
```

A patched package (again, for xenial) can be found [in this PPA](https://launchpad.net/~tribaal/+archive/ubuntu/unattended-upgrades)