### PR TITLE
Fix the systemd unit so it runs as an ExecStop and do not block when /var is separate

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,37 @@
+unattended-upgrades (0.93.1+nmu1) unstable; urgency=medium
+
+  * Non-maintainer upload.
+
+  [ Louis Bouchard ]
+  * Fix the unattended-upgrades.service unit not correctly working:
+    - d/rules : Remove the override_dh_installinit. The stop option is no longer
+      available so the command falls back to default. This is the normal
+      behavior so the override is not required
+    - d/unattended-upgrades.init : Add Default-Start runlevels, otherwise the 
+      unattended-upgrades.service unit cannot be enabled on boot
+    - d/postinst : Cleanup the stop symlinks created by the wrong
+      override_dh_installinit. Without that, the systemd unit cannot be
+      enabled correctly.
+      Force disable the service before deb-systemd-helper runs so the old 
+      symlink is not left dangling (workaround for Debian Bug #797108).
+      Force enable and start of the systemd unit to work around Debian Bug
+      #797108 which fails to enable systemd units correctly when WantedBy=
+      statement is changed which is the case here.
+    - d/unattended-upgrades.service : Fix the service so it runs correctly on
+      shutdown :
+        Remove DefaultDependencies=no : Breaks normal shutdown dependencies
+        Set After= to network.target and local-fs.target. Since our service is
+        now ExecStop, it will run before network and local-fs become
+        unavailable. Add RequiresMountsFor=/var/log /var/run /var/lib /boot : 
+        Necessary if /var is a separate file system. Set WantedBy= to
+        multi-user.target
+    - Add DEP8 tests to verify the following :
+      Verify that the unattended-upgrades.service unit is enabled and started.
+      Verify that InstallOnShutdown works when configured.
+    (Closes: #809669)
+
+ -- Gaudenz Steinlin <gaudenz@debian.org>  Sat, 06 May 2017 19:42:14 +0200
+
 unattended-upgrades (0.93.1) unstable; urgency=medium
 
   [ Brian Murray ]

--- a/debian/postinst
+++ b/debian/postinst
@@ -61,6 +61,20 @@ case "$1" in
             && [ -f /etc/rc6.d/S[0-9][0-9]unattended-upgrades ] ; then
             update-rc.d -f unattended-upgrades remove
         fi
+        # Recover from broken dh_installinit override in versions < 0.93.1+nmu1
+        if dpkg --compare-versions "$2" lt "0.93.1+nmu1"; then
+            if [ -f /etc/rc0.d/K[0-9][0-9]unattended-upgrades ] \
+            && [ -f /etc/rc6.d/K[0-9][0-9]unattended-upgrades ] ; then
+            	update-rc.d -f unattended-upgrades remove
+	    fi
+	    # If running systemd, explicitely disable the service otherwise
+	    # the shutdown.target symlink will remain (See Debian Bug #797108)
+	    if [ -d /run/systemd/system ]; then
+	        if deb-systemd-helper --quiet was-enabled unattended-upgrades.service; then
+	            deb-systemd-helper disable unattended-upgrades.service >/dev/null || true
+	        fi
+	    fi
+	fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)
@@ -77,6 +91,21 @@ esac
 
 #DEBHELPER#
 
+# Explicitly enable and start the service. Debian Bug #797108 for 
+# deb-systemd-helper fails to correctly enable the unit. It checks for 
+# enablement using the content of the WantedBy= which has changed so it
+# sees the service as disable and will not enable it.
+case "$1" in
+    configure)
+        if dpkg --compare-versions "$2" lt "0.93.1+nmu1" \
+	&& [ -d /run/systemd/system ]; then
+                # workaround systemd bug with enable --now which
+                # fails to start the unit
+		systemctl enable unattended-upgrades || true
+		systemctl start unattended-upgrades || true
+	fi
+    ;;
+esac
 exit 0
 
 

--- a/debian/rules
+++ b/debian/rules
@@ -28,8 +28,3 @@ override_dh_auto_clean:
 		rm -f $$f.py; \
 	done
 	$(PYTHON) setup.py clean -a
-
-override_dh_installinit:
-	# we do not want to run the init script in the postinst/prerm, its
-	#  really only useful on shutdown, see Debian bug #645919
-	dh_installinit $@ --no-start -- stop 10 0 6 .

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,2 +1,3 @@
-Tests: run-tests
+Tests: run-tests test-systemd.py
 Depends: @, @builddeps@
+Restrictions: needs-root, isolation-container

--- a/debian/tests/test-systemd.py
+++ b/debian/tests/test-systemd.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import subprocess
+
+
+def test_systemd_service():
+    '''
+    Verify that the unattended-upgrades.service unit is started
+    correctly. The unit must be started in order for the ExecStop=
+    to work correctly
+    '''
+    Service = 'unattended-upgrades.service'
+    try:
+        subprocess.check_output(['systemctl', '--quiet', 'is-active', Service])
+    except subprocess.CalledProcessError:
+        out = subprocess.getoutput(
+              'systemctl status unattended-upgrades.service')
+        print('test_systemd_service() FAILED\n%s' % out)
+        return False
+    return True
+
+
+def enable_install_on_shutdown():
+    '''
+    Enable InstallOnShutdown to verify that the command runs correctly
+    upon reboot
+    '''
+    apt_conf_file = '/etc/apt/apt.conf.d/50unattended-upgrades'
+    param = 'Unattended-Upgrade::InstallOnShutdown'
+    sed_cmd = 's/\/\/%s/%s/' % (param, param)
+
+    try:
+        subprocess.check_output(['/bin/sed', '-i', sed_cmd, apt_conf_file])
+    except subprocess.CalledProcessError:
+        print("Unable to edit %s" % apt_conf_file)
+        return False
+    return True
+
+
+def check_log_files():
+    '''
+    Verify that the logfiles are correctly produced by the InstallOnShutdown
+    run upon reboot. This will confirm that it did run correctly when we
+    rebooted.
+    '''
+    logdir = '/var/log/unattended-upgrades/'
+    logfiles = ['unattended-upgrades.log', 'unattended-upgrades-shutdown.log']
+
+    for file in logfiles:
+        if not os.path.exists(logdir + file):
+            print("File missing : %s" % (logdir + file))
+            return False
+    return True
+
+
+if __name__ == '__main__':
+    autopkgtest_reboot_mark = os.getenv('AUTOPKGTEST_REBOOT_MARK')
+
+    if autopkgtest_reboot_mark is None:
+        if not test_systemd_service():
+            sys.exit(1)
+
+        if enable_install_on_shutdown():
+            print('Rebooting to test InstallOnShutdown...')
+            subprocess.check_call(['/tmp/autopkgtest-reboot',
+                                   'InstallOnShutdown'])
+        else:
+            sys.exit(1)
+
+    if autopkgtest_reboot_mark == 'InstallOnShutdown':
+        if not check_log_files():
+            print("InstallOnShutdown did not run")
+            sys.exit(1)
+    else:
+        print('Invalid autopkgtest_reboot_mark value')
+        sys.exit(1)
+
+    sys.exit(0)

--- a/debian/unattended-upgrades.init
+++ b/debian/unattended-upgrades.init
@@ -4,7 +4,7 @@
 # Required-Start:    $local_fs $remote_fs
 # Required-Stop:     $local_fs $remote_fs
 # Provides:          unattended-upgrade-shutdown-check
-# Default-Start:
+# Default-Start:     2 3 4 5
 # Default-Stop:      0 6
 # Short-Description: Check if unattended upgrades are being applied
 # Description:       Check if unattended upgrades are being applied

--- a/debian/unattended-upgrades.service
+++ b/debian/unattended-upgrades.service
@@ -1,13 +1,14 @@
 [Unit]
 Description=Unattended Upgrades Shutdown
-DefaultDependencies=no
-Before=shutdown.target reboot.target halt.target network.target local-fs.target
+After=network.target local-fs.target
+RequiresMountsFor=/var/log /var/run /var/lib /boot
 Documentation=man:unattended-upgrade(8)
 
 [Service]
 Type=oneshot
-ExecStart=/usr/share/unattended-upgrades/unattended-upgrade-shutdown
-TimeoutStartSec=900
+RemainAfterExit=yes
+ExecStop=/usr/share/unattended-upgrades/unattended-upgrade-shutdown
+TimeoutStopSec=900
 
 [Install]
-WantedBy=shutdown.target
+WantedBy=multi-user.target


### PR DESCRIPTION
* Fix the unattended-upgrades.service unit not correctly working:
  - d/rules : Remove the override_dh_installinit. The stop option is no longer
    available so the command falls back to default. This is the normal
    behavior so the override is not required
  - d/unattended-upgrades.init : Add Default-Start runlevels, otherwise the
    unattended-upgrades.service unit cannot be enabled on boot
  - d/postinst : Cleanup the stop symlinks created by the wrong
    override_dh_installinit. Without that, the systemd unit cannot be
    enabled correctly.
    Force disable the service before deb-systemd-helper runs so the old
    symlink is not left dangling (workaround for Debian Bug #797108).
    Force enable and start of the systemd unit to work around Debian Bug
    #797108 which fails to enable systemd units correctly when WantedBy=
    statement is changed which is the case here.
  - d/unattended-upgrades.service : Fix the service so it runs correctly on
    shutdown :
      Remove DefaultDependencies=no : Breaks normal shutdown dependencies
      Set After= to network.target and local-fs.target. Since our service is
      now ExecStop, it will run before network and local-fs become
      unavailable. Add RequiresMountsFor=/var/log /var/run /var/lib /boot :
      Necessary if /var is a separate file system. Set WantedBy= to
      multi-user.target
  - Add DEP8 tests to verify the following :
    Verify that the unattended-upgrades.service unit is enabled and started.
    Verify that InstallOnShutdown works when configured.
  (Closes: #809669)