### PR TITLE
Fix failure to parse allowed origins

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+unattended-upgrades (0.93.2) UNRELEASED; urgency=medium
+
+  * unattended-upgrades: Provide some information and create a log entry when
+    there is a failure to parse the allowed origins. (LP: #1680599)
+
+ -- Brian Murray <brian@ubuntu.com>  Wed, 24 May 2017 12:03:02 -0700
+
 unattended-upgrades (0.93.1) unstable; urgency=medium
 
   [ Brian Murray ]

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -320,20 +320,25 @@ def get_distro_id():
 def get_allowed_origins_legacy():
     """ legacy support for old Allowed-Origins var """
     allowed_origins = []
-    for s in apt_pkg.config.value_list("Unattended-Upgrade::Allowed-Origins"):
-        # if there is a ":" use that as seperator, else use spaces
-        if re.findall(r'(?<!\\):', s):
-            (distro_id, distro_codename) = re.split(r'(?<!\\):', s)
-        else:
-            (distro_id, distro_codename) = s.split()
-        # unescape "\:" back to ":"
-        distro_id = re.sub(r'\\:', ':', distro_id)
-        # escape "," (see LP: #824856) - i wonder if there is a simpler way?
-        distro_id = re.sub(r'([^\\]),', r'\1\\,', distro_id)
-        distro_codename = re.sub(r'([^\\]),', r'\1\\,', distro_codename)
-        # convert to new format
-        allowed_origins.append("o=%s,a=%s" % (substitute(distro_id),
-                                              substitute(distro_codename)))
+    key = "Unattended-Upgrade::Allowed-Origins"
+    try:
+        for s in apt_pkg.config.value_list(key):
+            # if there is a ":" use that as seperator, else use spaces
+            if re.findall(r'(?<!\\):', s):
+                (distro_id, distro_codename) = re.split(r'(?<!\\):', s)
+            else:
+                (distro_id, distro_codename) = s.split()
+            # unescape "\:" back to ":"
+            distro_id = re.sub(r'\\:', ':', distro_id)
+            # escape "," (see LP: #824856) - can this be simpler?
+            distro_id = re.sub(r'([^\\]),', r'\1\\,', distro_id)
+            distro_codename = re.sub(r'([^\\]),', r'\1\\,', distro_codename)
+            # convert to new format
+            allowed_origins.append("o=%s,a=%s" % (substitute(distro_id),
+                                   substitute(distro_codename)))
+    except ValueError:
+        logging.error(_("Unable to parse %s." % key))
+        raise
     return allowed_origins
 
 
@@ -343,8 +348,13 @@ def get_allowed_origins():
     This will take substitutions (like distro_id) into account.
     """
     allowed_origins = get_allowed_origins_legacy()
-    for s in apt_pkg.config.value_list("Unattended-Upgrade::Origins-Pattern"):
-        allowed_origins.append(substitute(s))
+    key = "Unattended-Upgrade::Origins-Pattern"
+    try:
+        for s in apt_pkg.config.value_list(key):
+            allowed_origins.append(substitute(s))
+    except ValueError:
+        logging.error(_("Unable to parse %s." % key))
+        raise
     return allowed_origins
 
 


### PR DESCRIPTION
This fixes the bug found here:

https://bugs.launchpad.net/ubuntu/+source/unattended-upgrades/+bug/1680599