### PR TITLE
Do not automatically upgrade the development release of Ubuntu

### DIFF
--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -19,6 +19,10 @@ Unattended-Upgrade::Package-Blacklist {
 //	"libc6-i686";
 };
 
+// This option will controls whether the development release of Ubuntu will be
+// upgraded automatically.
+Unattended-Upgrade::DevRelease "false";
+
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run 
 //   dpkg --force-confold --configure -a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+unattended-upgrades (0.93.2) UNRELEASED; urgency=medium
+
+  * unattended-upgrades: Do not automatically upgrade the development release
+    of Ubuntu unless Unattended-Upgrade::DevRelease is true. (LP: #1649709)
+
+ -- Brian Murray <brian@ubuntu.com>  Wed, 24 May 2017 12:28:36 -0700
+
 unattended-upgrades (0.93.1) unstable; urgency=medium
 
   [ Brian Murray ]

--- a/test/test_remove_unused.py
+++ b/test/test_remove_unused.py
@@ -92,6 +92,7 @@ Unattended-Upgrade::Allowed-Origins {
 Unattended-Upgrade::Remove-Unused-Dependencies "true";
 """)
         options = MockOptions()
+        unattended_upgrade.DISTRO_DESC = "Ubuntu 10.04"
         unattended_upgrade.main(
             options, rootdir="./root.unused-deps")
         with open(self.log) as f:
@@ -113,6 +114,7 @@ Unattended-Upgrade::Allowed-Origins {
 Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
 """)
         options = MockOptions()
+        unattended_upgrade.DISTRO_DESC = "Ubuntu 10.04"
         unattended_upgrade.main(
             options, rootdir="./root.unused-deps")
         with open(self.log) as f:

--- a/test/test_untrusted.py
+++ b/test/test_untrusted.py
@@ -35,11 +35,18 @@ class TestUntrusted(unittest.TestCase):
         os.remove(self.log)
 
     def test_untrusted_check_without_conffile_check(self):
+        apt_conf = os.path.join(self.rootdir, "etc", "apt", "apt.conf")
+        with open(apt_conf, "w") as fp:
+            fp.write("""Unattended-Upgrade::Allowed-Origins {
+"Ubuntu:lucid-security";
+};
+""")
         # ensure there is no conffile_prompt check
         apt.apt_pkg.config.set("DPkg::Options::", "--force-confold")
 
         # run it
         options = MockOptions()
+        unattended_upgrade.DISTRO_DESC = "Ubuntu 10.04"
         unattended_upgrade.main(options, rootdir=self.rootdir)
         # read the log to see what happend
         with open(self.log) as f:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -68,6 +68,8 @@ USERS = "/usr/bin/users"
 # no py3 lsb_release in debian :/
 DISTRO_CODENAME = subprocess.check_output(
     ["lsb_release", "-c", "-s"], universal_newlines=True).strip()
+DISTRO_DESC = subprocess.check_output(
+    ["lsb_release", "-d", "-s"], universal_newlines=True).strip()
 DISTRO_ID = subprocess.check_output(
     ["lsb_release", "-i", "-s"], universal_newlines=True).strip()
 
@@ -1200,6 +1202,11 @@ def main(options, rootdir=""):
     if not is_update_day():
         return
 
+    # check to see if want to auto-upgrade the devel release
+    if "(development branch)" in DISTRO_DESC and not\
+            apt_pkg.config.find_b("Unattended-Upgrade::DevRelease", False):
+        logging.info(_("Not running on the development release."))
+        return
     # format (origin, archive), e.g. ("Ubuntu","dapper-security")
     allowed_origins = get_allowed_origins()
 


### PR DESCRIPTION
With unattended-upgrades being enabled by default in Ubuntu a side effect is the installing of any new packages when someone is running the development release.  This fixes that by adding a DevRelease configuration option which defaults to false.

The problem is documented here:

https://bugs.launchpad.net/ubuntu/+source/unattended-upgrades/+bug/1649709