### PR TITLE
allow configuration of a pre-execution hook for arbitrary conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ Supported Options Reference
  ```
  The default is an empty list which means updates are applied every day.
 
+* `Unattended-Upgrade::Special-Conditions-Script` - path to a script on which to make execution dependent
+
+ Allows the definition of arbitrary conditions for update execution.
+ If set, the given script is executed. If it returns 0, unattended-upgrades proceeds, otherwise it stops. 
+
+ Example - apply updates only with Ethernet and AC Power connected
+ ```
+ Unattended-Upgrade::Special-Conditions-Script "/home/me/scripts/check-eth-and-ac-connected.sh";
+ ```
 
 * `Unattended-Upgrade::SyslogEnable` - boolean (default:False)
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1200,6 +1200,12 @@ def main(options, rootdir=""):
     if not is_update_day():
         return
 
+    specialCondScript = apt_pkg.config.find("Unattended-Upgrade::Special-Conditions-Script", "")
+    if specialCondScript:
+        if subprocess.call([specialCondScript]) != 0:
+            logging.info("The script configured with Unattended-Upgrade::Special-Conditions-Script didn't return 0, stopping here!")
+            return
+
     # format (origin, archive), e.g. ("Ubuntu","dapper-security")
     allowed_origins = get_allowed_origins()
 


### PR DESCRIPTION
On my notebook, I wanted automatic updates to be done only when connected to Ethernet and AC Power.
Since I didn't find a way to do this with unattended-upgrades as is, I added a config option which allows to make execution dependent on arbitrary conditions by executing a given script and checking its return value.

Usage described in `README.md`

As an example, that's the script I'm using it with (tailored to my system):
```
#!/bin/bash

set -e
set -u

ETH_CONNECTED=false
AC_CONNECTED=false

# check Ethernet connected
if [[ `cat /sys/class/net/eth0/operstate` == "up" ]]; then
  ETH_CONNECTED=true
fi

# check AC connected
if [[ `cat /sys/devices/platform/smapi/ac_connected` == 1 ]]; then
  AC_CONNECTED=true
fi

if $ETH_CONNECTED && $AC_CONNECTED; then
  exit 0
fi

exit 1
```