### PR TITLE
Blacklisted packages are now added to the pkgs_kept_back list - fix for #52 ?

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1112,7 +1112,8 @@ def calculate_upgradable_pkgs(cache, options, allowed_origins,
                 pkg.name, getattr(pkg.candidate, "origins", [])))
 
         if (pkg.is_upgradable and
-                not is_pkgname_in_blacklist(pkg.name, blacklisted_pkgs, pkgs_kept_back) and
+                not is_pkgname_in_blacklist(pkg.name, blacklisted_pkgs,
+                                            pkgs_kept_back) and
                 is_pkgname_in_whitelist(pkg.name, whitelisted_pkgs) and
                 is_allowed_origin(pkg.candidate, allowed_origins)):
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -395,7 +395,7 @@ def match_whitelist_string(whitelist, origin):
             res &= fnmatch.fnmatch(origin.codename, value)
         else:
             raise UnknownMatcherError(
-                "Unknown whitelist entry for macher '%s' (token '%s')" % (
+                "Unknown whitelist entry for matcher '%s' (token '%s')" % (
                     what, token))
         # logging.debug("matching '%s'='%s' against '%s'" % (
         #              what, value, origin))
@@ -542,10 +542,11 @@ def is_allowed_origin(ver, allowed_origins):
     return False
 
 
-def is_pkgname_in_blacklist(pkgname, blacklist):
+def is_pkgname_in_blacklist(pkgname, blacklist, pkgs_kept_back):
     for blacklist_regexp in blacklist:
         if re.match(blacklist_regexp, pkgname):
             logging.debug("skipping blacklisted package '%s'" % pkgname)
+            pkgs_kept_back.append(pkgname)
             return True
     return False
 
@@ -582,7 +583,7 @@ def check_changes_for_sanity(cache, allowed_origins, blacklist, whitelist,
             if not is_allowed_origin(pkg.candidate, allowed_origins):
                 logging.debug("pkg '%s' not in allowed origin" % pkg.name)
                 return False
-            if is_pkgname_in_blacklist(pkg.name, blacklist):
+            if is_pkgname_in_blacklist(pkg.name, blacklist, []):
                 logging.debug("pkg '%s' package has been blacklisted" %
                               pkg.name)
                 return False
@@ -1109,8 +1110,9 @@ def calculate_upgradable_pkgs(cache, options, allowed_origins,
         if options.debug and pkg.is_upgradable:
             logging.debug("Checking: %s (%s)" % (
                 pkg.name, getattr(pkg.candidate, "origins", [])))
+
         if (pkg.is_upgradable and
-                not is_pkgname_in_blacklist(pkg.name, blacklisted_pkgs) and
+                not is_pkgname_in_blacklist(pkg.name, blacklisted_pkgs, pkgs_kept_back) and
                 is_pkgname_in_whitelist(pkg.name, whitelisted_pkgs) and
                 is_allowed_origin(pkg.candidate, allowed_origins)):
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -591,7 +591,7 @@ def is_allowed_origin(ver, allowed_origins):
 
 
 def is_pkgname_in_blacklist(pkgname, blacklist, pkgs_kept_back):
-    # type: (str, List[str]) -> bool
+    # type: (str, List[str], List[str]) -> bool
     for blacklist_regexp in blacklist:
         if re.match(blacklist_regexp, pkgname):
             logging.debug("skipping blacklisted package '%s'" % pkgname)


### PR DESCRIPTION
This pull request simply adds the relevant blacklisted package to the pkgs_kept_back list. To do this though it also required the calling functions to be passed the list.
Tested and seems to work okay when only blacklisted packages are available for updating, and for when there are blacklisted and 'ordinary' packages available (packages which are neither black nor white listed).
(One trivial typo also included.)