### PR TITLE
Fix for pep8 - closing bracket missing visual indentation

### DIFF
--- a/test/test_origin_pattern.py
+++ b/test/test_origin_pattern.py
@@ -200,8 +200,7 @@ class TestOriginPatern(unittest.TestCase):
                 ("http\://foo.bar:stable", ("http://foo.bar", "stable")),
                 # space as separator
                 ("Ubuntu lucid-security", ("Ubuntu", "lucid-security")),
-                ("http\://baz.mee stable", ("http://baz.mee", "stable")),
-        ):
+                ("http\://baz.mee stable", ("http://baz.mee", "stable"))):
             apt_pkg.config.clear("Unattended-Upgrade::Allowed-Origins")
             apt_pkg.config.set("Unattended-Upgrade::Allowed-Origins::", cfg)
             li = unattended_upgrade.get_allowed_origins_legacy()


### PR DESCRIPTION
Pep8 error when running tests:

> Running ./test_pep8.py with python3
> ./../test/test_origin_pattern.py:204:9: E124 closing bracket missing visual indentation
> F
> ======================================================================
> FAIL: test_pep8_clean (__main__.PackagePep8TestCase)
