### PR TITLE
There is no such Raspbian-Security label

### DIFF
--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -8,7 +8,7 @@
 // file, but several aliases are accepted.  The accepted keywords are:
 //   a,archive,suite (eg, "stable")
 //   c,component     (eg, "main", "contrib", "non-free")
-//   l,label         (eg, "Rapsbian", "Raspbian-Security")
+//   l,label         (eg, "Rapsbian", "Raspbian")
 //   o,origin        (eg, "Raspbian", "Unofficial Multimedia Packages")
 //   n,codename      (eg, "jessie", "jessie-updates")
 //     site          (eg, "http.debian.net")


### PR DESCRIPTION
According to [this](https://www.raspberrypi.org/forums/viewtopic.php?f=66&t=82863) Raspbian thread and my own testing, there is no _Raspbian-Security_ label. 

See also [this](https://github.com/jnv/ansible-role-unattended-upgrades/pull/20/commits/43830851211a87fcada9a43e3e22e8d8c3e61656)

> In Raspbian, it is only possible to update all packages from the default repository, including non-security updates, or updating none.