### PR TITLE
document and enable autoclean feature

### DIFF
--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -100,3 +100,5 @@ Unattended-Upgrade::Package-Blacklist {
 // Specify syslog facility. Default is daemon
 // Unattended-Upgrade::SyslogFacility "daemon";
 
+// Do "apt-get autoclean" every n-days (0=disable)
+APT::Periodic::AutocleanInterval "7";

--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -89,3 +89,6 @@ Unattended-Upgrade::Package-Blacklist {
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Do "apt-get autoclean" every n-days (0=disable)
+APT::Periodic::AutocleanInterval "7";

--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -73,3 +73,6 @@ Unattended-Upgrade::Package-Blacklist {
 
 // Specify syslog facility. Default is daemon
 // Unattended-Upgrade::SyslogFacility "daemon";
+
+// Do "apt-get autoclean" every n-days (0=disable)
+APT::Periodic::AutocleanInterval "7";


### PR DESCRIPTION
without this, unattended-upgrades will slowly fill up /var unless a
sysadmin sets up such an automated process or cleans up those packages
manually.

this is especially important on embeded systems (e.g. raspbian) where
disk space is sparse, but will eventually fill up any hard disk out
there. after a few months of operations here, I had a 6GB
/var/cache/apt/archives directory that eventually blocked email
delivery and caused a downtime.