### PR TITLE
Increase timeout to 30 minutes for u-u-s to finish before killing it

### DIFF
--- a/debian/unattended-upgrades.service
+++ b/debian/unattended-upgrades.service
@@ -8,7 +8,7 @@ Documentation=man:unattended-upgrade(8)
 Type=oneshot
 RemainAfterExit=yes
 ExecStop=/usr/share/unattended-upgrades/unattended-upgrade-shutdown
-TimeoutStopSec=900
+TimeoutStopSec=1800
 
 [Install]
 WantedBy=multi-user.target

--- a/unattended-upgrade-shutdown
+++ b/unattended-upgrade-shutdown
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     parser.add_option("", "--debug",
                       action="store_true", dest="debug", default=False,
                       help="print debug messages")
-    parser.add_option("", "--delay", default=10, type="int",
+    parser.add_option("", "--delay", default=25, type="int",
                       help="delay in minutes to wait for unattended-upgrades")
     parser.add_option("", "--lock-file",
                       default="/var/run/unattended-upgrades.lock",


### PR DESCRIPTION
Soft timeout until u-u-s is considered to be finished properly
is also increased to 25 minutes from 10 minutes.