### PR TITLE
Use test/aptroot instead of / as APT root directory in tests

### DIFF
--- a/test/test_against_real_archive.py
+++ b/test/test_against_real_archive.py
@@ -5,8 +5,9 @@ Note that this test is not run by the makefile in this folder, as it requires
 network access, and it fails in some situations (unclear which).
 """
 
-import apt
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
+import apt
 import glob
 import logging
 import os

--- a/test/test_clean.py
+++ b/test/test_clean.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 import unittest
 
+import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import apt
 import unattended_upgrade
 

--- a/test/test_conffile.py
+++ b/test/test_conffile.py
@@ -5,6 +5,7 @@ import logging
 import unittest
 
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 
 from unattended_upgrade import (
     conffile_prompt,

--- a/test/test_in_chroot.py
+++ b/test/test_in_chroot.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import apt
 import logging
 import glob

--- a/test/test_log_install_progress.py
+++ b/test/test_log_install_progress.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import logging
 import os
 import sys

--- a/test/test_logdir.py
+++ b/test/test_logdir.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import logging
 import os
 import sys

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -11,6 +11,7 @@ import unittest
 
 
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 
 import unattended_upgrade
 from unattended_upgrade import (

--- a/test/test_minimal_partitions.py
+++ b/test/test_minimal_partitions.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 
-import apt
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
+import apt
 import os
 import shutil
 import tempfile
@@ -33,6 +34,7 @@ class TestMinimalPartitions(unittest.TestCase):
 
     def setUp(self):
         # setup dry-run mode for apt
+        apt_pkg.config.set("Dir", "./aptroot")
         apt_pkg.config.set("Dir::Cache", "/tmp")
         apt_pkg.config.set("Debug::NoLocking", "1")
         apt_pkg.config.set("Debug::pkgDPkgPM", "1")

--- a/test/test_origin_pattern.py
+++ b/test/test_origin_pattern.py
@@ -4,6 +4,8 @@ import apt_pkg
 import logging
 import unittest
 
+apt_pkg.config.set("Dir", "./aptroot")
+
 import unattended_upgrade
 from unattended_upgrade import (
     check_changes_for_sanity,

--- a/test/test_reboot.py
+++ b/test/test_reboot.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 
 from mock import (
     patch,

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import io
 import os
 import sys

--- a/test/test_remove_unused.py
+++ b/test/test_remove_unused.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import unittest
 
+import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import apt
 
 import unattended_upgrade

--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -3,6 +3,8 @@
 import os
 import unittest
 
+import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import apt
 
 import unattended_upgrade

--- a/test/test_substitute.py
+++ b/test/test_substitute.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import logging
 import unittest
 

--- a/test/test_untrusted.py
+++ b/test/test_untrusted.py
@@ -3,6 +3,8 @@
 import os
 import unittest
 
+import apt_pkg
+apt_pkg.config.set("Dir", "./aptroot")
 import apt
 
 import unattended_upgrade


### PR DESCRIPTION
This prevents prevents system configuration from affecting test results.

Closes: #873079