### PR TITLE
Fix Raspbian default config codename matching

### DIFF
--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -35,7 +35,7 @@ Unattended-Upgrade::Origins-Pattern {
         // new stable).
 //      "o=Raspbian,a=stable";
 //      "o=Raspbian,a=testing";
-        "origin=Raspbian,archive=${distro_codename},label=Raspbian";
+        "origin=Raspbian,codename=${distro_codename},label=Raspbian";
 };
 
 // List of packages to not update (regexp are supported)


### PR DESCRIPTION
From my commit message:
> Using `archive=${distro_codename}` does not match, at least not in Raspbian Stretch anymore. Changing it to `codename=${distro_codename}`. I tested that it now works and did not notice any regressions.
> 
> Same change was made to the Debian-specific configuration 3 years ago, see commit 9a2afa5.

Note that this does not solve the current situation of Raspbian distributing the Debian-specific config file instead of the Raspbian-specific config file. This should be solved downstream at Raspbian, as discussed in issue #32. However, once that issue is solved, this change will be necessary anyway.