### PR TITLE
Add RPi-specific comment to Raspbian config file

### DIFF
--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -36,6 +36,10 @@ Unattended-Upgrade::Origins-Pattern {
 //      "o=Raspbian,a=stable";
 //      "o=Raspbian,a=testing";
         "origin=Raspbian,codename=${distro_codename},label=Raspbian";
+
+        // Additionally, for those running Raspbian on a Raspberry Pi,
+        // match packages from the Raspberry Pi Foundation as well.
+        "origin=Raspberry Pi Foundation,codename=${distro_codename},label=Raspberry Pi Foundation";
 };
 
 // List of packages to not update (regexp are supported)


### PR DESCRIPTION
In addition to the Raspbian repository, Raspbian images distributed by the Raspberry Pi Foundation (RPF) depend on the RPF repository for kernel and firmware updates. This commit adds comments and a commented pattern matching line to the unattended-upgrades Raspbian default config file. The pattern was taken from a comment by @pyllyukko in https://github.com/mvo5/unattended-upgrades/issues/32#issuecomment-331550938.

Notes:
- This does not solve the current situation of Raspbian distributing the Debian-specific config file instead of the Raspbian-specific config file. This should be solved downstream at Raspbian, as discussed in issue #32.
- Feel free to reject this PR if you feel this is a too downstream-specific customization.
- Background info on the RPF repository:
  > The raspberry Pi foundation have their own repository at http://archive.raspberrypi.org/debian/ which contains various packages they include in their images.
-- https://www.raspbian.org/RaspbianFAQ#Is_it_just_the_repository.3F__Or.2C_will_you_provide_any_customization.3F
  >
  > The Raspbian repo is basically a copy of the Debian one with packages compiled for the Pi. The RPF repo (archive.raspberrypi.org) just contains additions and modifications that the RPF made available.
-- https://www.raspberrypi.org/forums/viewtopic.php?f=66&t=195341&p=1222533#p1222533
  >
  > How do I restore the default repositories?
-- https://raspberrypi.stackexchange.com/questions/58335/how-do-i-restore-the-default-repositories