### PR TITLE
Consider conffile prompts to be errors

### DIFF
--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -154,15 +154,6 @@ Debian-Security']
         self.assertTrue(
             "Packages that attempted to upgrade:\n 2vcard" in mail_txt)
 
-    def test_mail_on_error_with_warning_in_log(self):
-        apt_pkg.config.set("Unattended-Upgrade::MailOnlyOnError", "true")
-        pkgs, res, pkgs_kept_back, mem_log, logf_dpkg = self._return_mock_data(
-            successful=True)
-        mem_log.write("\nWARNING: some warning\n")
-        send_summary_mail(pkgs, res, pkgs_kept_back, mem_log, logf_dpkg)
-        self.assertTrue(
-            os.path.exists(os.path.join(self.tmpdir, "mail.txt")))
-
     def test_summary_mail_blacklisted(self):
         # Test that blacklisted packages are mentioned in the mail message.
         send_summary_mail(*self._return_mock_data())

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1492,8 +1492,7 @@ def main(options, rootdir=""):
     if options.download_only:
         return 0
 
-    pkg_install_manual = False
-
+    pkg_conffile_prompt = False
     if dpkg_conffile_prompt():
         # now check the downloaded debs for conffile conflicts and build
         # a blacklist
@@ -1534,7 +1533,7 @@ def main(options, rootdir=""):
                                 pkgname_from_deb(item.destfile))
                 blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
                 pkgs_kept_back.append(pkgname_from_deb(item.destfile))
-                pkg_install_manual = True
+                pkg_conffile_prompt = True
 
         # redo the selection about the packages to upgrade based on the new
         # blacklist
@@ -1625,6 +1624,9 @@ def main(options, rootdir=""):
                                          whitelisted_pkgs,
                                          options,
                                          logfile_dpkg)
+    # Was the overall run succesful: only if everything installed
+    # fine and nothing was held back because of a conffile prompt.
+    successful_run = pkg_install_success and not pkg_conffile_prompt
 
     # now check if any auto-removing needs to be done
     cache = UnattendedUpgradesCache(
@@ -1664,7 +1666,7 @@ def main(options, rootdir=""):
     if not options.dry_run:
         log_content = get_dpkg_log_content(logfile_dpkg, install_start_time)
         send_summary_mail(
-            pkgs, pkg_install_success and not pkg_install_manual,
+            pkgs, successful_run,
             pkgs_kept_back, mem_log, log_content)
 
     # clean after success install (if needed)
@@ -1682,7 +1684,7 @@ def main(options, rootdir=""):
     # check if the user wants a reboot
     if not options.dry_run:
         reboot_if_requested_and_needed()
-    if pkg_install_success and not pkg_install_manual:
+    if successful_run:
         return 0
     else:
         return 1

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -945,10 +945,7 @@ def send_summary_mail(pkgs, res, pkgs_kept_back, mem_log, dpkg_log_content):
         return
     # if the operation was successful and the user has requested to get
     # mails on on errors, just exit here
-    if (res and
-        # see Debian Bug #703621
-        not re.search("^WARNING:", mem_log.getvalue(), re.MULTILINE) and
-        apt_pkg.config.find_b(
+    if (res and apt_pkg.config.find_b(
             "Unattended-Upgrade::MailOnlyOnError", False)):
         return
     # Check if reboot-required flag is present

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1492,6 +1492,8 @@ def main(options, rootdir=""):
     if options.download_only:
         return 0
 
+    pkg_install_manual = False
+
     if dpkg_conffile_prompt():
         # now check the downloaded debs for conffile conflicts and build
         # a blacklist
@@ -1532,6 +1534,7 @@ def main(options, rootdir=""):
                                 pkgname_from_deb(item.destfile))
                 blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
                 pkgs_kept_back.append(pkgname_from_deb(item.destfile))
+                pkg_install_manual = True
 
         # redo the selection about the packages to upgrade based on the new
         # blacklist
@@ -1661,7 +1664,8 @@ def main(options, rootdir=""):
     if not options.dry_run:
         log_content = get_dpkg_log_content(logfile_dpkg, install_start_time)
         send_summary_mail(
-            pkgs, pkg_install_success, pkgs_kept_back, mem_log, log_content)
+            pkgs, pkg_install_success and not pkg_install_manual,
+            pkgs_kept_back, mem_log, log_content)
 
     # clean after success install (if needed)
     keep_key = "Unattended-Upgrade::Keep-Debs-After-Install"
@@ -1678,7 +1682,7 @@ def main(options, rootdir=""):
     # check if the user wants a reboot
     if not options.dry_run:
         reboot_if_requested_and_needed()
-    if pkg_install_success:
+    if pkg_install_success and not pkg_install_manual:
         return 0
     else:
         return 1


### PR DESCRIPTION
Flag packages that have to be upgraded manually because of a conffile
prompt and consider this to be an error when sending email or exiting.

Fixes #89.