### PR TITLE
Add python, python3, setuptools, DistutilsExtra to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,11 +5,12 @@ Section: admin
 Testsuite: autopkgtest
 Priority: optional
 Build-Depends: debhelper (>= 9.20160709),
-               po-debconf
-Build-Depends-Indep: python,
-                     python3-distutils-extra,
-                     python3-setuptools,
-                     python-dev,
+               po-debconf,
+               python,
+               python3,
+               python3-distutils-extra,
+               python3-setuptools
+Build-Depends-Indep: python-dev,
                      python3-dev,
                      python-coverage,
                      pep8,


### PR DESCRIPTION
They are needed for `clean`, so Build-Depends-Indep is not enough.

Signed-off-by: Simon McVittie <smcv@collabora.com>

---

Policy §7.7 says `debian/rules clean` may be invoked with only the `Build-Depends`.