### PR TITLE
Add .gitignore, remove bzr glue

### DIFF
--- a/.bzr-builddeb/default.conf
+++ b/.bzr-builddeb/default.conf
@@ -1,5 +1,0 @@
-[BUILDDEB]
-native = True
-
-[HOOKS]
-pre-build = (./pre-build.sh && cd test && make && make clean)

--- a/.bzrignore
+++ b/.bzrignore
@@ -1,2 +1,0 @@
-__pycache__
-build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.egg-info/
+*.pyc
+/build/
+/test/.coverage
+/test/.mypy_cache/
+/test/root.*/
+/test/u-u.lock
+__pycache__/
+data/50unattended-upgrades

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,9 @@
+/*.debhelper.log
+/*.postinst.debhelper
+/*.postrm.debhelper
+/*.preinst.debhelper
+/*.prerm.debhelper
+/*.substvars
+/.debhelper/
+/files
+/unattended-upgrades/


### PR DESCRIPTION
This branch adds appropriate `.gitignore` files to ignore everything created by `debuild`.

unattended-upgrades also still contains `.bzrignore` and `.bzr-builddeb/`, which I don't think will ever be used now that it has been maintained in git for a while. This branch deletes them.