### PR TITLE
Update 50unattended-upgrades.Raspbian - semi-column to facilitate uncommenting

### DIFF
--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -79,7 +79,7 @@ Unattended-Upgrade::Package-Blacklist {
 
 // Remove unused automatically installed kernel-related packages
 // (kernel images, kernel headers and kernel version locked tools).
-//Unattended-Upgrade::Remove-Unused-Kernel-Packages "false"
+//Unattended-Upgrade::Remove-Unused-Kernel-Packages "false";
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)


### PR DESCRIPTION
added a semi-column sign on line 86 to facilitate uncommenting the line for users and not end up with an error message when running unattended-upgrades. And make the whole file consistent.