### PR TITLE
commented options should reflect default values

### DIFF
--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -64,7 +64,7 @@ Unattended-Upgrade::Package-Blacklist {
 // Install all unattended-upgrades when the machine is shutting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
-//Unattended-Upgrade::InstallOnShutdown "true";
+//Unattended-Upgrade::InstallOnShutdown "false";
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you

--- a/data/50unattended-upgrades.Devuan
+++ b/data/50unattended-upgrades.Devuan
@@ -66,7 +66,7 @@ Unattended-Upgrade::Package-Blacklist {
 // Install all unattended-upgrades when the machine is shutting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
-//Unattended-Upgrade::InstallOnShutdown "true";
+//Unattended-Upgrade::InstallOnShutdown "false";
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you

--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -65,7 +65,7 @@ Unattended-Upgrade::Package-Blacklist {
 // Install all unattended-upgrades when the machine is shutting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
-//Unattended-Upgrade::InstallOnShutdown "true";
+//Unattended-Upgrade::InstallOnShutdown "false";
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you

--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -39,7 +39,7 @@ Unattended-Upgrade::Package-Blacklist {
 // Install all unattended-upgrades when the machine is shutting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
-//Unattended-Upgrade::InstallOnShutdown "true";
+//Unattended-Upgrade::InstallOnShutdown "false";
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you


### PR DESCRIPTION
following https://github.com/mvo5/unattended-upgrades

`Unattended-Upgrade::InstallOnShutdown - boolean (default:False)`

it's common practice that commented options in config files show the defaults values, so when you uncomment it, nothing changes until the value is changed too