### PR TITLE
unattended-upgrades: fix Unlocked context manager

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -348,7 +348,7 @@ class Unlocked:
     def __exit__(self, exc_type, exc_value, exc_tb):
         # type: (object, object, object) -> None
         try:
-            apt_pkg.pkgsystem_unlock()
+            apt_pkg.pkgsystem_lock()
         except Exception:
             pass
 


### PR DESCRIPTION
The Unlocked context manager did correctly unlock but did not
reacquire the lock which means that in minimal-upgrade step
mode it is possible to run apt code without a lock. If something
else (like landscape, apt, synaptic, packagekit) locks the cache
in the meantime this will work and u-u will get dpkg errors
because dpkg will not be able to perform its operations. It is
less of an issue in non-minimal mode, but even then the auto-remove
step may fail in this way.

We should also SRU this fix.