### PR TITLE
Add logging for scheduled host reboot

### DIFF
--- a/test/test_reboot.py
+++ b/test/test_reboot.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import os
 import unittest
+import subprocess
 
 import apt_pkg
 apt_pkg.config.set("Dir", "./aptroot")
@@ -29,49 +30,54 @@ class RebootTestCase(unittest.TestCase):
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-WithUsers", "1")
 
-    @patch("subprocess.call")
+    @patch("subprocess.run")
     def test_no_reboot_done_because_no_stamp(self, mock_call):
         unattended_upgrade.REBOOT_REQUIRED_FILE = "/no/such/file/or/directory"
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(mock_call.called, False)
 
-    @patch("subprocess.call")
+    @patch("subprocess.run")
     def test_no_reboot_done_because_no_option(self, mock_call):
         apt_pkg.config.set("Unattended-Upgrade::Automatic-Reboot", "0")
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(mock_call.called, False)
 
-    @patch("subprocess.call")
-    def test_reboot_now(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={})
+    def test_reboot_now(self, mock_user, mock_call):
         unattended_upgrade.reboot_if_requested_and_needed()
-        mock_call.assert_called_with(["/sbin/shutdown", "-r", "now"])
+        mock_call.assert_called_with(["/sbin/shutdown", "-r", "now"],
+                                     stderr=subprocess.PIPE)
 
-    @patch("subprocess.call")
-    def test_reboot_time(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={})
+    def test_reboot_time(self, mock_users, mock_call):
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-Time", "03:00")
         unattended_upgrade.reboot_if_requested_and_needed()
-        mock_call.assert_called_with(["/sbin/shutdown", "-r", "03:00"])
+        mock_call.assert_called_with(["/sbin/shutdown", "-r", "03:00"],
+                                     stderr=subprocess.PIPE)
 
-    @patch("subprocess.call")
-    def test_reboot_withoutusers(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={})
+    def test_reboot_withoutusers(self, mock_users, mock_call):
         """Ensure that a reboot happens when no users are logged in"""
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-WithUsers", "0")
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-Time", "04:00")
         # some pgm that allways output nothing
-        unattended_upgrade.USERS = "/bin/true"
         unattended_upgrade.reboot_if_requested_and_needed()
-        mock_call.assert_called_with(["/sbin/shutdown", "-r", "04:00"])
+        mock_call.assert_called_with(["/sbin/shutdown", "-r", "04:00"],
+                                     stderr=subprocess.PIPE)
 
-    @patch("subprocess.call")
-    def test_reboot_withusers(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={'user'})
+    def test_reboot_withusers(self, mock_users, mock_call):
         """Ensure that a reboot does not happen if a user is logged in"""
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-WithUsers", "0")
         # some pgm that allways output a word
-        unattended_upgrade.USERS = "/bin/uname"
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(
             mock_call.called, False,

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1206,7 +1206,14 @@ def reboot_if_requested_and_needed():
     when = apt_pkg.config.find(
         "Unattended-Upgrade::Automatic-Reboot-Time", "now")
     logging.warning("Found %s, rebooting" % REBOOT_REQUIRED_FILE)
-    subprocess.call(["/sbin/shutdown", "-r", when])
+    cmd = ["/sbin/shutdown", "-r", when]
+    try:
+        proc = subprocess.run(cmd, stderr=PIPE)
+    except Exception as e:
+        logging.error("Failed to issue shutdown, %s", e)
+    else:
+        shut_msg = proc.stderr
+        logging.warning(shut_msg.strip())
 
 
 def write_stamp_file():


### PR DESCRIPTION
The shutdown command will print scheduled reboot to standard
error. This is not reflected in unattended-upgrades logs. What
is more, on Debian systems unattended-upgrade is typically invoked
by apt daily cron. Printing in stderr will result in cron email
notification to root user, which might be undesired given this
is not an actual error.

This commit grabs the reboot message and logs it. In case of
failure, exception will be logged as well.

test_reboot tests are modified accordingly. Since
reboot_if_requested_and_needed() calls logged_in_users() and both
end up using subprocess it's better to decouple them during tests
and avoid uncontrolled behavior. This is achieved by mocking
logged_in_users() and manipulating its return value.