### PR TITLE
Pu/types fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ before_install:
  - which python3
  - sudo apt-get install python3-pip
  - sudo python3 -m pip install -U mypy coverage
+ - git clone https://salsa.debian.org/apt-team/python-apt ../python-apt
 # travis is "funny" it has a non-distro python3 that will not find
 # python modules installed via apt-get
 # note that tests are run during package build
 script:
-  - dpkg-buildpackage -d -us -uc -rfakeroot
+  - MYPYPATH=$PWD/../python-apt:$PWD/../python-apt/typehinting dpkg-buildpackage -d -us -uc -rfakeroot
   - sudo dpkg -i ../unattended-upgrades_*.deb
   - sudo unattended-upgrades --help

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -144,7 +144,7 @@ class UnattendedUpgradesCache(apt.Cache):
         self.adjust_candidates()
 
     def open(self, progress=None):
-        # type: (apt.progress.base.Progress) -> None
+        # type: (apt.progress.base.OpProgress) -> None
         apt.Cache.open(self, progress)
         # ensure we update the candidate versions
         self.adjust_candidates()
@@ -160,7 +160,7 @@ class UnattendedUpgradesCache(apt.Cache):
             self[pkgname].candidate = candidate
 
     def _get_candidates_to_adjust(self):
-        # type: () -> Dict[str, apt.Version]
+        # type: () -> Dict[str, apt.package.Version]
         """ Get candidate versions needed to be adjusted to match highest
             allowed origin
 
@@ -1316,7 +1316,7 @@ def get_auto_removable(cache):
 
 def is_autoremove_valid(cache, pkgname, auto_removable, blacklisted_pkgs,
                         whitelisted_pkgs):
-    # type: (apt.Cache, str, AbstractSet[str], List[str], List[str]) -> bool
+    # type: (UnattendedUpgradesCache, str, AbstractSet[str], List[str], List[str]) -> bool  # nopep8
     changes = cache.get_changes()
     if not changes:
         # package is already removed
@@ -1355,7 +1355,7 @@ def is_autoremove_valid(cache, pkgname, auto_removable, blacklisted_pkgs,
     return True
 
 
-def do_auto_remove(cache,             # type: apt.Cache
+def do_auto_remove(cache,             # type: UnattendedUpgradesCache
                    auto_removable,    # type: AbstractSet[str]
                    logfile_dpkg,      # type: str
                    minimal_steps,     # type: bool

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -173,8 +173,7 @@ class UnattendedUpgradesCache(apt.Cache):
         if self._cached_candidate_pkgnames is None:
             pkg_iter = iter(self.keys())
         else:
-            pkg_iter = iter(
-                [self[name] for name in self._cached_candidate_pkgnames])
+            pkg_iter = iter(self._cached_candidate_pkgnames)
         for pkgname in pkg_iter:
             pkg = self[pkgname]
             # important! this avoids downgrades below

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1143,20 +1143,23 @@ def _setup_logging(options):
     if syslogEnable:
         syslogFacility = apt_pkg.config.find(
             "Unattended-Upgrade::SyslogFacility",
-            "daemon")
-        syslogHandler = logging.handlers.SysLogHandler(
-            address='/dev/log',
-            facility=syslogFacility)
-        syslogHandler.setFormatter(
-            logging.Formatter("unattended-upgrade: %(message)s"))
-        known = syslogHandler.facility_names.keys()  # type: ignore
-        if syslogFacility.lower() in known:
+            "daemon").lower()
+
+        try:
+            syslogFacilityId = logging.handlers.SysLogHandler.facility_names[syslogFacility]  # type: ignore # nopep8
+        except KeyError:
+            logging.warning("Syslog facility %s was not found"
+                            % syslogFacility)
+        else:
+            syslogHandler = logging.handlers.SysLogHandler(
+                address='/dev/log',
+                facility=syslogFacilityId)
+            syslogHandler.setFormatter(
+                logging.Formatter("unattended-upgrade: %(message)s"))
+
             logger.addHandler(syslogHandler)
             logging.info("Enabled logging to syslog via %s facility "
                          % syslogFacility)
-        else:
-            logging.warning("Syslog facility %s was not found"
-                            % syslogFacility)
     return mem_log
 
 


### PR DESCRIPTION
Adjust types to work with upcoming python-apt type hints. There is still one failure:

```test/unattended_upgrade.py:1147: error: Argument "facility" to "SysLogHandler" has incompatible type "str"; expected "int"```

Which seems correct according to documentation, but that might be a bug in documentation and mypy's type hints.