### PR TITLE
Ignored `.idea` and `.mypy_cache` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /test/u-u.lock
 __pycache__/
 data/50unattended-upgrades
+.idea/
+.mypy_cache/


### PR DESCRIPTION
Under no circumstances any of those would be committed ever.

How about ignoring them so that `git status` output was cleaner?