### PR TITLE
Send emails on errors or exceptions occured

### DIFF
--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -99,6 +99,7 @@ class CommonTestsForMailxAndSendmail(object):
         """ return input tuple for send_summary_mail """
         pkgs = ["2vcard"]
         res = successful
+        result_str = "Result String"
         pkgs_kept_back = ["linux-image"]
         pkgs_removed = ["telnet"]
         pkgs_kept_installed = ["hello"]
@@ -113,8 +114,8 @@ Debian-Security']
         random logfile_dpkg text
         Log ended: 2013-01-01  12:30:00
         """)
-        return (pkgs, res, pkgs_kept_back, pkgs_removed, pkgs_kept_installed,
-                mem_log, dpkg_log_content)
+        return (pkgs, res, result_str, pkgs_kept_back, pkgs_removed,
+                pkgs_kept_installed, mem_log, dpkg_log_content)
 
     def _verify_common_mail_content(self, mail_txt):
         for expected_string in self.EXPECTED_MAIL_CONTENT_STRINGS:
@@ -165,7 +166,7 @@ Debian-Security']
         with open(os.path.join(self.tmpdir, "mail.txt"), "rb") as fp:
             mail_txt = fp.read().decode("utf-8")
         self._verify_common_mail_content(mail_txt)
-        self.assertTrue("Unattended upgrade returned: False" in mail_txt)
+        self.assertTrue("Unattended upgrade result: Result String" in mail_txt)
         self.assertTrue(
             os.path.exists(os.path.join(self.tmpdir, "mail.txt")))
         self.assertTrue(
@@ -187,10 +188,11 @@ Debian-Security']
     def test_summary_mail_blacklisted_only(self):
         # Test that when only blacklisted packages are available, they
         # are still mentioned in the mail message.
-        pkgs, res, pkgs_kept_back, pkgs_removed, pkgs_kept_installed, \
-            mem_log, logf_dpkg = self._return_mock_data(successful=True)
+        pkgs, res, result_str, pkgs_kept_back, pkgs_removed, \
+            pkgs_kept_installed, mem_log, logf_dpkg = self._return_mock_data(
+                successful=True)
         pkgs = []
-        send_summary_mail(pkgs, res, pkgs_kept_back, pkgs_removed,
+        send_summary_mail(pkgs, res, result_str, pkgs_kept_back, pkgs_removed,
                           pkgs_kept_installed, mem_log, logf_dpkg)
         self.assertTrue(
             os.path.exists(os.path.join(self.tmpdir, "mail.txt")))

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -225,10 +225,10 @@ Debian-Security']
         self.assertTrue(
             "From: rootolv" in mail_txt, "missing From: in %s" % mail_txt)
 
-    @patch("unattended_upgrade.main_inner")
-    def test_exception(self, mock_main_inner):
+    @patch("unattended_upgrade.run")
+    def test_exception(self, mock_run):
         exception_string = "Test exception for email"
-        mock_main_inner.side_effect = Exception(exception_string)
+        mock_run.side_effect = Exception(exception_string)
         # run it
         options = MockOptions()
         unattended_upgrade.LOCK_FILE = "./u-u.lock"

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -97,7 +97,7 @@ class CommonTestsForMailxAndSendmail(object):
 
     def _return_mock_data(self, successful=True):
         """ return input tuple for send_summary_mail """
-        pkgs = "\n".join(["2vcard"])
+        pkgs = ["2vcard"]
         res = successful
         pkgs_kept_back = ["linux-image"]
         pkgs_removed = ["telnet"]
@@ -189,7 +189,7 @@ Debian-Security']
         # are still mentioned in the mail message.
         pkgs, res, pkgs_kept_back, pkgs_removed, pkgs_kept_installed, \
             mem_log, logf_dpkg = self._return_mock_data(successful=True)
-        pkgs = ""
+        pkgs = []
         send_summary_mail(pkgs, res, pkgs_kept_back, pkgs_removed,
                           pkgs_kept_installed, mem_log, logf_dpkg)
         self.assertTrue(

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -811,7 +811,7 @@ def conffile_prompt(destFile, prefix=""):
         print(_("error message: %s") % e)
         logging.error(_("Apt returned an error, exiting"))
         logging.error(_("error message: %s"), e)
-        sys.exit(1)
+        raise
     except LookupError as e:
         logging.debug("No conffiles in deb %s (%s)" % (destFile, e))
 
@@ -1499,8 +1499,38 @@ def main(options, rootdir=""):
     if rootdir:
         _setup_alternative_rootdir(rootdir)
 
+    # see debian #776752
+    install_start_time = datetime.datetime.now().replace(microsecond=0)
+
     # setup logging
     mem_log = _setup_logging(options)
+    # get log
+    logfile_dpkg = os.path.join(_get_logdir(), 'unattended-upgrades-dpkg.log')
+    if not os.path.exists(logfile_dpkg):
+        with open(logfile_dpkg, 'w'):
+            pass
+
+    ret = 1
+    try:
+        ret = main_inner(options, rootdir, mem_log, logfile_dpkg,
+                         install_start_time)
+    except Exception as e:
+        logger = logging.getLogger()
+        logger.exception(_("An error occurred: %s"), e)
+        # Re-raise exceptions for apport
+        raise
+    finally:
+        if not ret == 0:
+            log_content = get_dpkg_log_content(logfile_dpkg,
+                                               install_start_time)
+            send_summary_mail("<unknown>", False, [],
+                              [], [],
+                              mem_log, log_content)
+    return ret
+
+
+def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
+    # type: (Options, str, StringIO, str, datetime.datetime) -> int
 
     # check if today is a patch day
     if not is_update_day():
@@ -1525,13 +1555,10 @@ def main(options, rootdir=""):
     shutdown_lock = apt_pkg.get_lock(LOCK_FILE)
     if shutdown_lock < 0:
         logging.error("Lock file is already taken, exiting")
-        sys.exit(1)
+        return 1
 
     # display available origin
     logging.info(_("Allowed origins are: %s"), ", ".join(allowed_origins))
-
-    # see debian #776752
-    install_start_time = datetime.datetime.now().replace(microsecond=0)
 
     # check and get lock
     try:
@@ -1540,7 +1567,7 @@ def main(options, rootdir=""):
         logging.error(_("Lock could not be acquired (another package "
                         "manager running?)"))
         print(_("Cache lock can not be acquired, exiting"))
-        sys.exit(1)
+        return 1
 
     # check if the journal is dirty and if so, take emergceny action
     # the alternative is to leave the system potentially unsecure until
@@ -1573,12 +1600,12 @@ def main(options, rootdir=""):
         print(_("error message: %s") % error)
         logging.error(_("Apt returned an error, exiting"))
         logging.error(_("error message: %s"), error)
-        sys.exit(1)
+        return 1
 
     if cache._depcache.broken_count > 0:
         print(_("Cache has broken packages, exiting"))
         logging.error(_("Cache has broken packages, exiting"))
-        sys.exit(1)
+        return 1
 
     # FIXME: make this into a ContextManager
     # be nice when calculating the upgrade as its pretty CPU intensive
@@ -1649,13 +1676,13 @@ def main(options, rootdir=""):
                       item.desc_uri)
                 logging.error(_("The URI %s failed to download, aborting"),
                               item.desc_uri)
-                sys.exit(1)
+                return 1
             if not os.path.exists(item.destfile):
                 print(_("Download finished, but file %s not there?!?") %
                       item.destfile)
                 logging.error("Download finished, but file %s not "
                               "there?!?", item.destfile)
-                sys.exit(1)
+                return 1
             if not item.is_trusted:
                 blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
             if conffile_prompt(item.destfile):
@@ -1706,12 +1733,6 @@ def main(options, rootdir=""):
                         pkg2.mark_upgrade(from_user=not pkg2.is_auto_installed)
     else:
         logging.debug("dpkg is configured not to cause conffile prompts")
-
-    # get log
-    logfile_dpkg = os.path.join(_get_logdir(), 'unattended-upgrades-dpkg.log')
-    if not os.path.exists(logfile_dpkg):
-        with open(logfile_dpkg, 'w'):
-            pass
 
     # auto-removals
     auto_removable = get_auto_removable(cache)
@@ -1805,7 +1826,7 @@ def main(options, rootdir=""):
     if cache._depcache.broken_count > 0:
         print(_("Cache has broken packages, exiting"))
         logging.error(_("Cache has broken packages, exiting"))
-        sys.exit(1)
+        return 1
 
     # the user wants *all* auto-removals to be removed
     # (unless u-u got signalled to stop gracefully quickly)

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -367,6 +367,30 @@ class Unlocked:
             apt_pkg.pkgsystem_lock()
 
 
+class UnattendedUpgradesResult:
+    """
+    Represent the (potentially partial) results of an unattended-upgrades
+    run
+    """
+    def __init__(self,
+                 success,                 # type: bool
+                 result_str="",           # type: str
+                 pkgs=[],                 # type: List[str]
+                 pkgs_kept_back=[],       # type: List[str]
+                 pkgs_removed=[],         # type: List[str]
+                 pkgs_kept_installed=[],  # type: List[str]
+                 update_stamp=False       # type: bool
+                 ):
+        # type: (...) -> None
+        self.success = success
+        self.result_str = result_str
+        self.pkgs = pkgs
+        self.pkgs_kept_back = pkgs_kept_back
+        self.pkgs_removed = pkgs_removed
+        self.pkgs_kept_installed = pkgs_kept_installed
+        self.update_stamp = update_stamp
+
+
 def is_dpkg_journal_dirty():
     # type: () -> bool
     """
@@ -990,6 +1014,7 @@ def _send_mail_using_sendmail(from_address, to_address, subject, body):
 
 def send_summary_mail(pkgs,                 # type: List[str]
                       res,                  # type: bool
+                      result_str,           # type: str
                       pkgs_kept_back,       # type: List[str]
                       pkgs_removed,         # type: List[str]
                       pkgs_kept_installed,  # type: List[str]
@@ -1022,8 +1047,9 @@ def send_summary_mail(pkgs,                 # type: List[str]
         "{hold_flag}{reboot_flag} unattended-upgrades result for "
         "{machine}: {result}").format(
             hold_flag=hold_flag_str, reboot_flag=reboot_flag_str,
-            machine=host(), result=res).strip()
-    body = _("Unattended upgrade returned: %s\n\n") % res
+            machine=host(), result="SUCCESS" if res else "FAILURE").strip()
+    body = wrap(_("Unattended upgrade result: %s") % result_str, 70, " ")
+    body += "\n\n"
     if os.path.isfile(REBOOT_REQUIRED_FILE):
         body += _(
             "Warning: A reboot is required to complete this upgrade.\n\n")
@@ -1516,31 +1542,59 @@ def main(options, rootdir=""):
         with open(logfile_dpkg, 'w'):
             pass
 
-    ret = 1
+    # lock for the shutdown check
+    shutdown_lock = apt_pkg.get_lock(LOCK_FILE)
+    if shutdown_lock < 0:
+        logging.error("Lock file is already taken, exiting")
+        return 1
+
     try:
-        ret = main_inner(options, rootdir, mem_log, logfile_dpkg,
+        res = main_inner(options, rootdir, mem_log, logfile_dpkg,
                          install_start_time)
+        if res.result_str and not options.dry_run:
+            # there is some meaningful result which is worth an email
+            log_content = get_dpkg_log_content(logfile_dpkg,
+                                               install_start_time)
+            send_summary_mail(res.pkgs, res.success, res.result_str,
+                              res.pkgs_kept_back, res.pkgs_removed,
+                              res.pkgs_kept_installed, mem_log,
+                              log_content)
+        if res.update_stamp:
+            # write timestamp file
+            write_stamp_file()
+            if not options.dry_run:
+                # check if the user wants a reboot
+                reboot_if_requested_and_needed()
+        os.close(shutdown_lock)
+        if res.success:
+            return 0
+        else:
+            return 1
+
     except Exception as e:
         logger = logging.getLogger()
         logger.exception(_("An error occurred: %s"), e)
-        # Re-raise exceptions for apport
-        raise
-    finally:
-        if not ret == 0:
-            log_content = get_dpkg_log_content(logfile_dpkg,
-                                               install_start_time)
-            send_summary_mail(["<unknown>"], False, [],
+        log_content = get_dpkg_log_content(logfile_dpkg,
+                                           install_start_time)
+        if not options.dry_run:
+            send_summary_mail(["<unknown>"], False, _("An error occurred"), [],
                               [], [],
                               mem_log, log_content)
-    return ret
+        # Re-raise exceptions for apport
+        raise
 
 
-def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
-    # type: (Options, str, StringIO, str, datetime.datetime) -> int
+def main_inner(options,             # type: Options
+               rootdir,             # type: str
+               mem_log,             # type: StringIO
+               logfile_dpkg,        # type: str
+               install_start_time,  # type: datetime.datetime
+               ):
+    # type: (...) -> UnattendedUpgradesResult
 
     # check if today is a patch day
     if not is_update_day():
-        return 0
+        return UnattendedUpgradesResult(True)
 
     # format (origin, archive), e.g. ("Ubuntu","dapper-security")
     allowed_origins = get_allowed_origins()
@@ -1557,12 +1611,6 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
 
     logging.info(_("Starting unattended upgrades script"))
 
-    # lock for the shutdown check
-    shutdown_lock = apt_pkg.get_lock(LOCK_FILE)
-    if shutdown_lock < 0:
-        logging.error("Lock file is already taken, exiting")
-        return 1
-
     # display available origin
     logging.info(_("Allowed origins are: %s"), ", ".join(allowed_origins))
 
@@ -1573,7 +1621,8 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
         logging.error(_("Lock could not be acquired (another package "
                         "manager running?)"))
         print(_("Cache lock can not be acquired, exiting"))
-        return 1
+        return UnattendedUpgradesResult(
+            False, _("Lock could not be acquired"))
 
     # check if the journal is dirty and if so, take emergceny action
     # the alternative is to leave the system potentially unsecure until
@@ -1606,12 +1655,14 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
         print(_("error message: %s") % error)
         logging.error(_("Apt returned an error, exiting"))
         logging.error(_("error message: %s"), error)
-        return 1
+        return UnattendedUpgradesResult(
+            False, _("Apt returned an error, exiting"))
 
     if cache._depcache.broken_count > 0:
         print(_("Cache has broken packages, exiting"))
         logging.error(_("Cache has broken packages, exiting"))
-        return 1
+        return UnattendedUpgradesResult(
+            False, _("Cache has broken packages, exiting"))
 
     # FIXME: make this into a ContextManager
     # be nice when calculating the upgrade as its pretty CPU intensive
@@ -1655,7 +1706,7 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
     # TODO: download files one by one and check for stop request after each of
     # them
     if should_stop():
-        return 1
+        return UnattendedUpgradesResult(False, _("Upgrade was interrupted"))
     try:
         pm.get_archives(fetcher, list, recs)
     except SystemError as e:
@@ -1667,7 +1718,7 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
         logging.error("fetch.run() result: %s", e)
 
     if options.download_only:
-        return 0
+        return UnattendedUpgradesResult(True)
 
     pkg_conffile_prompt = False
     if dpkg_conffile_prompt():
@@ -1683,13 +1734,17 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
                       item.desc_uri)
                 logging.error(_("The URI %s failed to download, aborting"),
                               item.desc_uri)
-                return 1
+                return UnattendedUpgradesResult(
+                    False, (_("The URI %s failed to download, aborting") %
+                            item.desc_uri))
             if not os.path.exists(item.destfile):
                 print(_("Download finished, but file %s not there?!?") %
                       item.destfile)
                 logging.error("Download finished, but file %s not "
                               "there?!?", item.destfile)
-                return 1
+                return UnattendedUpgradesResult(
+                    False, (_("Download finished, but file %s not there?!?") %
+                            item.destfile))
             if not item.is_trusted:
                 blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
             if conffile_prompt(item.destfile):
@@ -1784,15 +1839,13 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
             len(pkgs_kept_back) == 0):
         logging.info(_("No packages found that can be upgraded unattended "
                        "and no pending auto-removals"))
-        # FIXME: DRY violation, write_stamp_file() is used below as well
-        write_stamp_file()
-        # check if we couldn't reboot on previous run because
-        # a user was logged-in at this time
-        os.close(shutdown_lock)
-        # never reboot during a dry run
-        if not options.dry_run:
-            reboot_if_requested_and_needed()
-        return 0
+        return UnattendedUpgradesResult(
+            kernel_pkgs_remove_success,
+            _("No packages found that can be upgraded unattended and no "
+              "pending auto-removals"),
+            pkgs_removed=kernel_pkgs_removed,
+            pkgs_kept_installed=kernel_pkgs_kept_installed,
+            update_stamp=True)
 
     # check if its configured for install on shutdown, if so, the
     # environment UNATTENDED_UPGRADES_FORCE_INSTALL_ON_SHUTDOWN will
@@ -1802,8 +1855,7 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
                 "Unattended-Upgrade::InstallOnShutdown", False)):
         logger = logging.getLogger()
         logger.debug("Configured to install on shutdown, so exiting now")
-        os.close(shutdown_lock)
-        return 0
+        return UnattendedUpgradesResult(True)
 
     # check if we are in dry-run mode
     if options.dry_run:
@@ -1833,7 +1885,8 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
     if cache._depcache.broken_count > 0:
         print(_("Cache has broken packages, exiting"))
         logging.error(_("Cache has broken packages, exiting"))
-        return 1
+        return UnattendedUpgradesResult(
+            False, _("Cache has broken packages, exiting"), pkgs=pkgs)
 
     # the user wants *all* auto-removals to be removed
     # (unless u-u got signalled to stop gracefully quickly)
@@ -1871,16 +1924,6 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
                      cache._depcache.del_count,
                      cache._depcache.broken_count))
 
-    # send a mail (if needed)
-    if not options.dry_run:
-        log_content = get_dpkg_log_content(logfile_dpkg, install_start_time)
-        send_summary_mail(
-            pkgs, successful_run,
-            pkgs_kept_back,
-            kernel_pkgs_removed + pkgs_removed,
-            kernel_pkgs_kept_installed + pkgs_kept_installed,
-            mem_log, log_content)
-
     # clean after success install (if needed)
     keep_key = "Unattended-Upgrade::Keep-Debs-After-Install"
     if (not apt_pkg.config.find_b(keep_key, False) and
@@ -1888,18 +1931,12 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
             pkg_install_success):
         clean_downloaded_packages(fetcher)
 
-    # FIXME: DRY violation, write_stamp_file() is used above as well
-    # write timestamp file
-    write_stamp_file()
-
-    os.close(shutdown_lock)
-    # check if the user wants a reboot
-    if not options.dry_run:
-        reboot_if_requested_and_needed()
-    if successful_run:
-        return 0
-    else:
-        return 1
+    return UnattendedUpgradesResult(
+        successful_run, _("All upgrades installed"), pkgs,
+        pkgs_kept_back,
+        kernel_pkgs_removed + pkgs_removed,
+        kernel_pkgs_kept_installed + pkgs_kept_installed,
+        update_stamp=True)
 
 
 class Options:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -988,9 +988,15 @@ def _send_mail_using_sendmail(from_address, to_address, subject, body):
     return ret
 
 
-def send_summary_mail(pkgs, res, pkgs_kept_back, pkgs_removed,
-                      pkgs_kept_installed, mem_log, dpkg_log_content):
-    # type: (str, bool, List[str], List[str], List[str], StringIO, str) -> None
+def send_summary_mail(pkgs,                 # type: List[str]
+                      res,                  # type: bool
+                      pkgs_kept_back,       # type: List[str]
+                      pkgs_removed,         # type: List[str]
+                      pkgs_kept_installed,  # type: List[str]
+                      mem_log,              # type: StringIO
+                      dpkg_log_content,     # type: str
+                      ):
+    # type: (...) -> None
     """ send mail (if configured in Unattended-Upgrade::Mail) """
     to_email = apt_pkg.config.find("Unattended-Upgrade::Mail", "")
     if not to_email:
@@ -1025,7 +1031,7 @@ def send_summary_mail(pkgs, res, pkgs_kept_back, pkgs_removed,
         body += _("Packages that were upgraded:\n")
     else:
         body += _("Packages that attempted to upgrade:\n")
-    body += " " + wrap(pkgs, 70, " ")
+    body += " " + wrap(" ".join(pkgs), 70, " ")
     body += "\n"
     if pkgs_kept_back:
         body += _("Packages with upgradable origin but kept back:\n")
@@ -1523,7 +1529,7 @@ def main(options, rootdir=""):
         if not ret == 0:
             log_content = get_dpkg_log_content(logfile_dpkg,
                                                install_start_time)
-            send_summary_mail("<unknown>", False, [],
+            send_summary_mail(["<unknown>"], False, [],
                               [], [],
                               mem_log, log_content)
     return ret
@@ -1628,8 +1634,9 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
     pkgs_to_upgrade, pkgs_kept_back = calculate_upgradable_pkgs(
         cache, options, allowed_origins, blacklisted_pkgs, whitelisted_pkgs)
     pkgs_to_upgrade.sort(key=lambda p: p.name)
-    pkgs = "\n".join([pkg.name for pkg in pkgs_to_upgrade])
-    logging.debug("pkgs that look like they should be upgraded: %s" % pkgs)
+    pkgs = [pkg.name for pkg in pkgs_to_upgrade]
+    logging.debug("pkgs that look like they should be upgraded: %s"
+                  % "\n".join(pkgs))
 
     # FIXME: make this into a ContextManager
     # stop being nice
@@ -1804,8 +1811,8 @@ def main_inner(options, rootdir, mem_log, logfile_dpkg, install_start_time):
         apt_pkg.config.set("Debug::pkgDPkgPM", "1")
 
     # do the install based on the new list of pkgs
-    pkgs = " ".join([pkg.name for pkg in pkgs_to_upgrade])
-    logging.info(_("Packages that will be upgraded: %s"), pkgs)
+    pkgs = [pkg.name for pkg in pkgs_to_upgrade]
+    logging.info(_("Packages that will be upgraded: %s"), " ".join(pkgs))
 
     # only perform install step if we actually have packages to install
     pkg_install_success = True

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1549,8 +1549,8 @@ def main(options, rootdir=""):
         return 1
 
     try:
-        res = main_inner(options, rootdir, mem_log, logfile_dpkg,
-                         install_start_time)
+        res = run(options, rootdir, mem_log, logfile_dpkg,
+                  install_start_time)
         if res.result_str and not options.dry_run:
             # there is some meaningful result which is worth an email
             log_content = get_dpkg_log_content(logfile_dpkg,
@@ -1584,12 +1584,12 @@ def main(options, rootdir=""):
         raise
 
 
-def main_inner(options,             # type: Options
-               rootdir,             # type: str
-               mem_log,             # type: StringIO
-               logfile_dpkg,        # type: str
-               install_start_time,  # type: datetime.datetime
-               ):
+def run(options,             # type: Options
+        rootdir,             # type: str
+        mem_log,             # type: StringIO
+        logfile_dpkg,        # type: str
+        install_start_time,  # type: datetime.datetime
+        ):
     # type: (...) -> UnattendedUpgradesResult
 
     # check if today is a patch day


### PR DESCRIPTION
This helps monitoring hosts running u-u and also helps getting bug reports from Debian users because the exceptions occurring on Debian are not collected at errors.ubuntu.com.