### PR TITLE
Further speed improvements and releasing 1.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,42 @@
+unattended-upgrades (1.4) unstable; urgency=medium
+
+  * Skip starting init.d script in debhelper-generated postinst part
+    (LP: #1778800)
+  * Use "deb-systemd-invoke start" instead of "systemctl start" in postinst.
+    It is used only in a workaround applied for a Debian bug and for upgrading
+    from pre-bionic versions.
+  * Clear cache when autoremoval is invalid for a package set marked for
+    removal (LP: #1779157)
+  * Clear cache after failed commits to return from a possibly invalid state
+  * Unlock for dpkg operations with apt_pkg.pkgsystem_unlock_inner() when it
+    is available, also stop running when reacquiring the lock fails.
+    Thanks to to Julian Andres Klode for original partial patch
+  * Use fully qualified domain name in email subject.
+  * Send email about all failures and crashes (Closes: #898607)
+  * Add short textual summary of the results in the summary email
+  * Recommend overriding configuration in a separate file.
+    This can be better than changing /etc/apt/apt.conf.d/50unattended-upgrades
+    because package updates don't conflict with local changes this way.
+  * Adjust candidates only for packages to be possibly installed
+    (Closes: #892028, #899366) (LP: #1396787)
+  * Add Unattended-Upgrade::OnlyOnACPower config file example for all
+    distributions
+  * debian/control: Drop redundant Testsuite: autopkgtest field to keep Lintian
+    happy
+  * Bump Standards-Version to 4.1.4
+  * Add debian/tests/upgrade-all-security to install all current security
+    updates. On development releases this tests latest stable, on stable
+    releases it tests the release itself.
+  * Skip updates on metered connections (Closes: #855570)
+  * Quote shell variables in autopkgtest
+  * Stop u-u early when it should stop later anyway
+  * Measure time for --dry-run and after all updates are installed in
+    autopkgtests
+  * Filter out packages cheaper when they are not from allowed origins
+  * Collect autoremovable packages, too, when looking for upgradable ones
+
+ -- Balint Reczey <rbalint@ubuntu.com>  Thu, 05 Jul 2018 23:36:00 +0200
+
 unattended-upgrades (1.3) unstable; urgency=medium
 
   [ Balint Reczey ]

--- a/debian/tests/common-functions
+++ b/debian/tests/common-functions
@@ -30,7 +30,7 @@ do_debootstrap() {
     chroot_dir="$2"
     mirror="$3"
 
-    debootstrap --include eatmydata "$@"
+    debootstrap --include eatmydata,time "$@"
 
     mount --bind /dev/pts "$chroot_dir/dev/pts"
     mount --bind /proc "$chroot_dir/proc"
@@ -67,7 +67,10 @@ run_u_u() {
 
     echo 'Unattended-Upgrade::Mail "root";' > "$chroot_dir/etc/apt/apt.conf.d/51unattended-upgrades-mail"
     chroot_exec "$chroot_dir" apt-get update
+    chroot_exec "$chroot_dir" unattended-upgrade --download-only
+    chroot_exec "$chroot_dir" time unattended-upgrade --verbose --dry-run 2>&1
     chroot_exec "$chroot_dir" unattended-upgrade --verbose --debug
+    chroot_exec "$chroot_dir" time unattended-upgrade --verbose 2>&1
     echo "new packages marked as manually installed (should be none): "
     chroot_exec "$chroot_dir" apt-mark showmanual | diff "$chroot_dir/tmp/manual" -
     chroot_exec "$chroot_dir" perl -MMIME::QuotedPrint -pe '$_=MIME::QuotedPrint::decode($_);' /var/mail/mail

--- a/debian/tests/upgrade-all-security
+++ b/debian/tests/upgrade-all-security
@@ -42,7 +42,14 @@ cp ../unattended-upgrades_*.deb "$chroot_dir/tmp/"
 chroot_exec "$chroot_dir" bash -c 'apt install -y /tmp/unattended-upgrades_*deb' 2>&1
 
 sed "s/$distro/$distro-updates/" < "$chroot_dir/etc/apt/sources.list" > "$chroot_dir/etc/apt/sources.list.d/updates.list"
-sed "s/$distro/$distro-security/" < "$chroot_dir/etc/apt/sources.list" > "$chroot_dir/etc/apt/sources.list.d/security.list"
+case "$(dpkg-vendor --query Vendor)" in
+    "Ubuntu")
+        sed "s/$distro/$distro-security/" < "$chroot_dir/etc/apt/sources.list" > "$chroot_dir/etc/apt/sources.list.d/security.list"
+        ;;
+    "Debian")
+        echo "deb http://security.debian.org/ $distro/updates main" > "$chroot_dir/etc/apt/sources.list.d/security.list"
+        ;;
+esac
 
 chroot_exec "$chroot_dir" apt-get update
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1313,6 +1313,15 @@ def try_to_upgrade(pkg,               # type: apt.Package
                    ):
     # type: (...) -> None
     try:
+        try:
+            # try to adjust pkg itself first, if that throws an exception it
+            # can't be upgraded on its own
+            cache.adjust_candidate(pkg)
+            if not pkg.is_upgradable:
+                return
+        except NoAllowedOriginError:
+            return
+        cache._cached_candidate_pkgnames.add(pkg.name)
         cache.mark_upgrade_adjusted(pkg, from_user=not pkg.is_auto_installed)
         if check_changes_for_sanity(cache, allowed_origins,
                                     blacklisted_pkgs, whitelisted_pkgs,

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -121,7 +121,7 @@ class UnattendedUpgradesCache(apt.Cache):
 
     def __init__(self, rootdir, allowed_origins):
         # type: (str, List[str]) -> None
-        self._cached_candidate_pkgnames = None  # type: AbstractSet[str]
+        self._cached_candidate_pkgnames = set()  # type: AbstractSet[str]
         self.allowed_origins = allowed_origins
         apt.Cache.__init__(self, rootdir=rootdir)
 
@@ -172,8 +172,13 @@ class UnattendedUpgradesCache(apt.Cache):
            Note that as a side effect more package's candidate can be
            adjusted than only the one's in the final changes set.
         """
-        pkgs_to_adjust = []  # List[str]
+        new_pkgs_to_adjust = []  # List[str]
         pkgs_with_no_allowed_origin = []
+
+        # adjust candidates in advance if needed
+        for pkg_name in self._cached_candidate_pkgnames:
+            self.adjust_candidate(self[pkg_name])
+
         if function == apt.package.Package.mark_upgrade \
            and not pkg.is_upgradable:
             raise NoAllowedOriginError
@@ -188,13 +193,14 @@ class UnattendedUpgradesCache(apt.Cache):
                     # important! this avoids downgrades below
                     if pkg.is_installed and not pkg.is_upgradable:
                         continue
-                    pkgs_to_adjust.append(marked_pkg)
+                    new_pkgs_to_adjust.append(marked_pkg)
                 except NoAllowedOriginError:
                     pkgs_with_no_allowed_origin.append(marked_pkg)
 
-        if pkgs_to_adjust:
-            for pkg_to_adjust in pkgs_to_adjust:
+        if new_pkgs_to_adjust:
+            for pkg_to_adjust in new_pkgs_to_adjust:
                 self.adjust_candidate(pkg_to_adjust)
+                self._cached_candidate_pkgnames.add(pkg_to_adjust.name)
             self.call_adjusted(function, pkg, **kwargs)
         else:
             if pkgs_with_no_allowed_origin:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -122,6 +122,7 @@ class UnattendedUpgradesCache(apt.Cache):
     def __init__(self, rootdir, allowed_origins):
         # type: (str, List[str]) -> None
         self._cached_candidate_pkgnames = set()  # type: AbstractSet[str]
+        self.initial_autoremovable_pkgs = set()  # type: AbstractSet[str]
         self.allowed_origins = allowed_origins
         apt.Cache.__init__(self, rootdir=rootdir)
 
@@ -1361,6 +1362,10 @@ def calculate_upgradable_pkgs(cache,             # type: apt.Cache
 
     # now do the actual upgrade
     for pkg in cache:
+        # cache already autoremovable packages to avoid the first filtering
+        # for them
+        if pkg.is_auto_removable:
+            cache.initial_autoremovable_pkgs.add(pkg.name)
         if options.debug and pkg.is_upgradable:
             logging.debug("Checking: %s (%s)" % (
                 pkg.name, getattr(pkg.candidate, "origins", [])))
@@ -1839,7 +1844,7 @@ def run(options,             # type: Options
         logging.debug("dpkg is configured not to cause conffile prompts")
 
     # auto-removals
-    auto_removable = get_auto_removable(cache)
+    auto_removable = cache.initial_autoremovable_pkgs
     kernel_pkgs_remove_success = True  # type: bool
     kernel_pkgs_removed = []           # type: List[str]
     kernel_pkgs_kept_installed = []    # type: List[str]


### PR DESCRIPTION
Now u-u finishes under 3s when no package needs to be upgraded even when there are packages to be kept back in not allowed origins.
To have another 2x speedup python-apt need to be changed IMO:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=903108