### PR TITLE
 Add logging for scheduled host reboot

### DIFF
--- a/test/test_reboot.py
+++ b/test/test_reboot.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import os
 import unittest
+import subprocess
 
 import apt_pkg
 apt_pkg.config.set("Dir", "./aptroot")
@@ -29,49 +30,54 @@ class RebootTestCase(unittest.TestCase):
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-WithUsers", "1")
 
-    @patch("subprocess.call")
+    @patch("subprocess.run")
     def test_no_reboot_done_because_no_stamp(self, mock_call):
         unattended_upgrade.REBOOT_REQUIRED_FILE = "/no/such/file/or/directory"
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(mock_call.called, False)
 
-    @patch("subprocess.call")
+    @patch("subprocess.run")
     def test_no_reboot_done_because_no_option(self, mock_call):
         apt_pkg.config.set("Unattended-Upgrade::Automatic-Reboot", "0")
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(mock_call.called, False)
 
-    @patch("subprocess.call")
-    def test_reboot_now(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={})
+    def test_reboot_now(self, mock_user, mock_call):
         unattended_upgrade.reboot_if_requested_and_needed()
-        mock_call.assert_called_with(["/sbin/shutdown", "-r", "now"])
+        mock_call.assert_called_with(["/sbin/shutdown", "-r", "now"],
+                                     stderr=subprocess.PIPE)
 
-    @patch("subprocess.call")
-    def test_reboot_time(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={})
+    def test_reboot_time(self, mock_users, mock_call):
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-Time", "03:00")
         unattended_upgrade.reboot_if_requested_and_needed()
-        mock_call.assert_called_with(["/sbin/shutdown", "-r", "03:00"])
+        mock_call.assert_called_with(["/sbin/shutdown", "-r", "03:00"],
+                                     stderr=subprocess.PIPE)
 
-    @patch("subprocess.call")
-    def test_reboot_withoutusers(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={})
+    def test_reboot_withoutusers(self, mock_users, mock_call):
         """Ensure that a reboot happens when no users are logged in"""
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-WithUsers", "0")
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-Time", "04:00")
         # some pgm that allways output nothing
-        unattended_upgrade.USERS = "/bin/true"
         unattended_upgrade.reboot_if_requested_and_needed()
-        mock_call.assert_called_with(["/sbin/shutdown", "-r", "04:00"])
+        mock_call.assert_called_with(["/sbin/shutdown", "-r", "04:00"],
+                                     stderr=subprocess.PIPE)
 
-    @patch("subprocess.call")
-    def test_reboot_withusers(self, mock_call):
+    @patch("subprocess.run")
+    @patch("unattended_upgrade.logged_in_users", return_value={'user'})
+    def test_reboot_withusers(self, mock_users, mock_call):
         """Ensure that a reboot does not happen if a user is logged in"""
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-WithUsers", "0")
         # some pgm that allways output a word
-        unattended_upgrade.USERS = "/bin/uname"
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(
             mock_call.called, False,

--- a/test/test_reboot.py
+++ b/test/test_reboot.py
@@ -30,35 +30,35 @@ class RebootTestCase(unittest.TestCase):
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-WithUsers", "1")
 
-    @patch("subprocess.run")
+    @patch("subprocess.check_output")
     def test_no_reboot_done_because_no_stamp(self, mock_call):
         unattended_upgrade.REBOOT_REQUIRED_FILE = "/no/such/file/or/directory"
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(mock_call.called, False)
 
-    @patch("subprocess.run")
+    @patch("subprocess.check_output")
     def test_no_reboot_done_because_no_option(self, mock_call):
         apt_pkg.config.set("Unattended-Upgrade::Automatic-Reboot", "0")
         unattended_upgrade.reboot_if_requested_and_needed()
         self.assertEqual(mock_call.called, False)
 
-    @patch("subprocess.run")
+    @patch("subprocess.check_output", return_value="some shutdown msg")
     @patch("unattended_upgrade.logged_in_users", return_value={})
     def test_reboot_now(self, mock_user, mock_call):
         unattended_upgrade.reboot_if_requested_and_needed()
         mock_call.assert_called_with(["/sbin/shutdown", "-r", "now"],
-                                     stderr=subprocess.PIPE)
+                                     stderr=subprocess.STDOUT)
 
-    @patch("subprocess.run")
+    @patch("subprocess.check_output", return_value="some shutdown msg")
     @patch("unattended_upgrade.logged_in_users", return_value={})
     def test_reboot_time(self, mock_users, mock_call):
         apt_pkg.config.set(
             "Unattended-Upgrade::Automatic-Reboot-Time", "03:00")
         unattended_upgrade.reboot_if_requested_and_needed()
         mock_call.assert_called_with(["/sbin/shutdown", "-r", "03:00"],
-                                     stderr=subprocess.PIPE)
+                                     stderr=subprocess.STDOUT)
 
-    @patch("subprocess.run")
+    @patch("subprocess.check_output", return_value="some shutdown msg")
     @patch("unattended_upgrade.logged_in_users", return_value={})
     def test_reboot_withoutusers(self, mock_users, mock_call):
         """Ensure that a reboot happens when no users are logged in"""
@@ -69,9 +69,9 @@ class RebootTestCase(unittest.TestCase):
         # some pgm that allways output nothing
         unattended_upgrade.reboot_if_requested_and_needed()
         mock_call.assert_called_with(["/sbin/shutdown", "-r", "04:00"],
-                                     stderr=subprocess.PIPE)
+                                     stderr=subprocess.STDOUT)
 
-    @patch("subprocess.run")
+    @patch("subprocess.check_output")
     @patch("unattended_upgrade.logged_in_users", return_value={'user'})
     def test_reboot_withusers(self, mock_users, mock_call):
         """Ensure that a reboot does not happen if a user is logged in"""

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1206,7 +1206,14 @@ def reboot_if_requested_and_needed():
     when = apt_pkg.config.find(
         "Unattended-Upgrade::Automatic-Reboot-Time", "now")
     logging.warning("Found %s, rebooting" % REBOOT_REQUIRED_FILE)
-    subprocess.call(["/sbin/shutdown", "-r", when])
+    cmd = ["/sbin/shutdown", "-r", when]
+    try:
+        proc = subprocess.run(cmd, stderr=PIPE)
+    except Exception as e:
+        logging.error("Failed to issue shutdown, %s", e)
+    else:
+        shut_msg = proc.stderr
+        logging.warning(shut_msg.strip())
 
 
 def write_stamp_file():

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -43,7 +43,7 @@ import subprocess
 import sys
 
 try:
-    from typing import AbstractSet, Dict, Iterable, List, Tuple
+    from typing import AbstractSet, cast, Dict, Iterable, List, Tuple
     AbstractSet  # pyflakes
     Dict  # pyflakes
     Iterable  # pyflakes
@@ -1893,7 +1893,7 @@ if __name__ == "__main__":
                       action="store_true",
                       help=SUPPRESS_HELP,
                       default=False)
-    (options, args) = parser.parse_args()  # type: ignore
+    options = cast(Options, (parser.parse_args())[0])
 
     if os.getuid() != 0:
         print(_("You need to be root to run this application"))

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1208,12 +1208,11 @@ def reboot_if_requested_and_needed():
     logging.warning("Found %s, rebooting" % REBOOT_REQUIRED_FILE)
     cmd = ["/sbin/shutdown", "-r", when]
     try:
-        proc = subprocess.run(cmd, stderr=PIPE)
+        shutdown_msg = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        if shutdown_msg.strip():
+            logging.warning("Shutdown msg: %s", shutdown_msg.strip())
     except Exception as e:
-        logging.error("Failed to issue shutdown, %s", e)
-    else:
-        shut_msg = proc.stderr
-        logging.warning(shut_msg.strip())
+        logging.error("Failed to issue shutdown: %s", e)
 
 
 def write_stamp_file():


### PR DESCRIPTION
This is https://github.com/mvo5/unattended-upgrades/pull/115 with the small tweak to use subprocess.check_call() which is available on more python versions and seems to be equivalent otherwise.

It also contains one cherry-pick from @rbalint to fix the mypy checks.