### PR TITLE
Clarify 'A reboot is required' warning

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1083,7 +1083,8 @@ def send_summary_mail(pkgs,                 # type: List[str]
     body += "\n\n"
     if os.path.isfile(REBOOT_REQUIRED_FILE):
         body += _(
-            "Warning: A reboot is required to complete this upgrade, or a previous one.\n\n")
+            "Warning: A reboot is required to complete this upgrade, "
+            "or a previous one.\n\n")
     if pkgs:
         if res:
             body += _("Packages that were upgraded:\n")

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1083,7 +1083,7 @@ def send_summary_mail(pkgs,                 # type: List[str]
     body += "\n\n"
     if os.path.isfile(REBOOT_REQUIRED_FILE):
         body += _(
-            "Warning: A reboot is required to complete this upgrade.\n\n")
+            "Warning: A reboot is required to complete this upgrade, or a previous one.\n\n")
     if pkgs:
         if res:
             body += _("Packages that were upgraded:\n")


### PR DESCRIPTION
The presence of `REBOOT_REQUIRED_FILE=/var/run/reboot-required` does not necessarily mean it was created by the current run of unattended-upgrades. 

Quite often, it was a result of a previous run of UU.