### PR TITLE
Stop using ActionGroups, they interfere with apt.Cache.clear()

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -135,7 +135,6 @@ class UnattendedUpgradesCache(apt.Cache):
     def __init__(self, rootdir, allowed_origins):
         # type: (str, List[str]) -> None
         self._cached_candidate_pkgnames = set()  # type: AbstractSet[str]
-        self.initial_autoremovable_pkgs = set()  # type: AbstractSet[str]
         self.allowed_origins = allowed_origins
         apt.Cache.__init__(self, rootdir=rootdir)
 
@@ -1430,10 +1429,6 @@ def calculate_upgradable_pkgs(cache,             # type: apt.Cache
 
     # now do the actual upgrade
     for pkg in cache:
-        # cache already autoremovable packages to avoid the first filtering
-        # for them
-        if pkg.is_auto_removable:
-            cache.initial_autoremovable_pkgs.add(pkg.name)
         if options.debug and pkg.is_upgradable:
             logging.debug("Checking: %s (%s)" % (
                 pkg.name, getattr(pkg.candidate, "origins", [])))
@@ -1823,9 +1818,7 @@ def run(options,             # type: Options
         else:
             raise
 
-    # speed things up with latest apt
-    actiongroup = apt_pkg.ActionGroup(cache._depcache)
-    actiongroup  # pyflakes
+    auto_removable = get_auto_removable(cache)
 
     # find out about the packages that are upgradable (in an allowed_origin)
     pkgs_to_upgrade, pkgs_kept_back = calculate_upgradable_pkgs(
@@ -1949,7 +1942,6 @@ def run(options,             # type: Options
         logging.debug("dpkg is configured not to cause conffile prompts")
 
     # auto-removals
-    auto_removable = cache.initial_autoremovable_pkgs
     kernel_pkgs_remove_success = True  # type: bool
     kernel_pkgs_removed = []           # type: List[str]
     kernel_pkgs_kept_installed = []    # type: List[str]


### PR DESCRIPTION
causing all autoremovable packages to be handled as newly autoremovable ones
and be removed by default. Dropping ActionGroup usage does not slow down the
most frequent case of not having anything to upgrade and when ther are
packages to upgrade the gain is small compared to the actual package
installation.

Also collect autoremovable packages before adjusting candidates because that
also changed .is_auto_removable attribute of some of them.

LP: #1803749
Closes: #910874