### PR TITLE
Fix location of shutdown lock with rootdir, and enable test_dev_relea…

### DIFF
--- a/test/test_dev_release.py
+++ b/test/test_dev_release.py
@@ -21,19 +21,35 @@ class MockOptions(object):
 class TestUntrusted(unittest.TestCase):
 
     def setUp(self):
+        apt.apt_pkg.config.set("Unattended-Upgrade::"
+                               "Skip-Updates-On-Metered-Connections",
+                               "false")
+        apt.apt_pkg.config.set("Unattended-Upgrade::OnlyOnAcPower",
+                               "false")
+        unattended_upgrade.LOCK_FILE = "./u-u.lock"
         self.rootdir = os.path.abspath("./root.untrusted")
         self.log = os.path.join(
             self.rootdir, "var", "log", "unattended-upgrades",
             "unattended-upgrades.log")
 
+        self.apt_conf = os.path.join(self.rootdir, "etc", "apt",
+                                     "apt.conf")
+
+        os.rename(self.apt_conf, self.apt_conf + ".bak")
+
     def tearDown(self):
         os.remove(self.log)
+        os.rename(self.apt_conf + ".bak", self.apt_conf)
+
+    def write_config(self, devrelease):
+        with open(self.apt_conf, "w") as fp:
+            fp.write("""Unattended-Upgrade::DevRelease "%s";
+Unattended-Upgrade::Skip-Updates-On-Metered-Connections "false";
+Unattended-Upgrade::OnlyOnAcPower "false";
+""" % devrelease)
 
     def test_do_not_run_on_devrelease(self):
-        apt_conf = os.path.join(self.rootdir, "etc", "apt", "apt.conf")
-        with open(apt_conf, "w") as fp:
-            fp.write("""Unattended-Upgrade::DevRelease "false";
-""")
+        self.write_config("false")
 
         # run it
         options = MockOptions()


### PR DESCRIPTION
…se.py

This failed because u-u was using the host's lock file, instead of
one inside the temporary root.