### PR TITLE
Fix blacklists, clear cache only when needed, add --no-minimal-steps, improve tests and fix regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Supported Options Reference
  Example:
  ```
  Unattended-Upgrade::Package-Blacklist {
-     "libstdc\+\+6";
+     "libstdc\+\+6$";
  };
  ```
 

--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -41,12 +41,26 @@ Unattended-Upgrade::Origins-Pattern {
 //      "o=Debian Backports,a=${distro_codename}-backports,l=Debian Backports";
 };
 
-// List of packages to not update (regexp are supported)
+// Python regular expressions, matching packages to exclude from upgrading
 Unattended-Upgrade::Package-Blacklist {
-//     "vim";
-//     "libc6";
-//     "libc6-dev";
-//     "libc6-i686";
+    // The following matches all packages starting with linux-
+//  "linux-";
+
+    // Use $ to explicitely define the end of a package name. Without
+    // the $, "libc6" would match all of them.
+//  "libc6$";
+//  "libc6-dev$";
+//  "libc6-i686$";
+
+    // Special characters need escaping
+//  "libstdc\+\+6$";
+
+    // The following matches packages like xen-system-amd64, xen-utils-4.1,
+    // xenstore-utils and libxenstore3.0
+    "(lib)?xen(store)?";
+
+    // For more information about Python regular expressions, see
+    // https://docs.python.org/3/howto/regex.html
 };
 
 // This option allows you to control if on a unclean dpkg exit

--- a/data/50unattended-upgrades.Devuan
+++ b/data/50unattended-upgrades.Devuan
@@ -43,12 +43,26 @@ Unattended-Upgrade::Origins-Pattern {
         "a=*-security";
 };
 
-// List of packages to not update (regexp are supported)
+// Python regular expressions, matching packages to exclude from upgrading
 Unattended-Upgrade::Package-Blacklist {
-//	"vim";
-//	"libc6";
-//	"libc6-dev";
-//	"libc6-i686";
+    // The following matches all packages starting with linux-
+//  "linux-";
+
+    // Use $ to explicitely define the end of a package name. Without
+    // the $, "libc6" would match all of them.
+//  "libc6$";
+//  "libc6-dev$";
+//  "libc6-i686$";
+
+    // Special characters need escaping
+//  "libstdc\+\+6$";
+
+    // The following matches packages like xen-system-amd64, xen-utils-4.1,
+    // xenstore-utils and libxenstore3.0
+    "(lib)?xen(store)?";
+
+    // For more information about Python regular expressions, see
+    // https://docs.python.org/3/howto/regex.html
 };
 
 // This option allows you to control if on a unclean dpkg exit

--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -42,12 +42,26 @@ Unattended-Upgrade::Origins-Pattern {
         "origin=Raspberry Pi Foundation,codename=${distro_codename},label=Raspberry Pi Foundation";
 };
 
-// List of packages to not update (regexp are supported)
+// Python regular expressions, matching packages to exclude from upgrading
 Unattended-Upgrade::Package-Blacklist {
-//	"vim";
-//	"libc6";
-//	"libc6-dev";
-//	"libc6-i686";
+    // The following matches all packages starting with linux-
+//  "linux-";
+
+    // Use $ to explicitely define the end of a package name. Without
+    // the $, "libc6" would match all of them.
+//  "libc6$";
+//  "libc6-dev$";
+//  "libc6-i686$";
+
+    // Special characters need escaping
+//  "libstdc\+\+6$";
+
+    // The following matches packages like xen-system-amd64, xen-utils-4.1,
+    // xenstore-utils and libxenstore3.0
+    "(lib)?xen(store)?";
+
+    // For more information about Python regular expressions, see
+    // https://docs.python.org/3/howto/regex.html
 };
 
 // This option allows you to control if on a unclean dpkg exit

--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -16,12 +16,26 @@ Unattended-Upgrade::Allowed-Origins {
 //	"${distro_id}:${distro_codename}-backports";
 };
 
-// List of packages to not update (regexp are supported)
+// Python regular expressions, matching packages to exclude from upgrading
 Unattended-Upgrade::Package-Blacklist {
-//	"vim";
-//	"libc6";
-//	"libc6-dev";
-//	"libc6-i686";
+    // The following matches all packages starting with linux-
+//  "linux-";
+
+    // Use $ to explicitely define the end of a package name. Without
+    // the $, "libc6" would match all of them.
+//  "libc6$";
+//  "libc6-dev$";
+//  "libc6-i686$";
+
+    // Special characters need escaping
+//  "libstdc\+\+6$";
+
+    // The following matches packages like xen-system-amd64, xen-utils-4.1,
+    // xenstore-utils and libxenstore3.0
+    "(lib)?xen(store)?";
+
+    // For more information about Python regular expressions, see
+    // https://docs.python.org/3/howto/regex.html
 };
 
 // This option controls whether the development release of Ubuntu will be

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,47 @@
+unattended-upgrades (1.9) UNRELEASED; urgency=medium
+
+  [ Julian Andres Klode ]
+  * test_dev_release: Fix and enable test.
+  * Depend on python3-distro-info.
+    This is needed to make sure DEVEL_UNTIL_RELEASE actually works. We need
+    to fix up travis in addition to control, as it only knows about trusty
+    build dependencies.
+  * Import distro_info globally, and fix calculation of days.
+    The check was off by one: If you were 21 days away from the release,
+    it would not switch on, but tell you that it would not upgrade before
+    today.
+  * test_dev_release: Test Unattended-Upgrade::DevRelease=auto.
+
+  [ David Lang and Balint Reczey]
+  * Allow installing untrusted packages when APT::Get::AllowUnauthenticated
+    is set (Closes: #775469) (LP: #1167053)
+
+  [ Hans van Kranenburg and Balint Reczey]
+  * Clarify highly misleading Package-Blacklist option documentation
+    (Closes: #753892)
+
+  [ Balint Reczey ]
+  * test/test_dev_release.py: Fix missing mock attributes
+  * Leave the cache clean when returning from calculate_upgradable_pkgs()
+    When collecting upgradable packages the upgradable ones stayed in the
+    cache and they were upgraded together even when unattended-upgrades
+    was configured to perform upgrades in minimal steps.
+    Thanks to Paul Wise
+  * debian/tests/upgrade-all-security: Check if all security-updates are
+    applied and if old-autoremovable packages are kept
+  * Clear cache only when needed when checking black- and whitelists
+  * Add --no-minimal-upgrade-steps option
+  * Stop using untrusted package names as blacklists (LP: #1805447)
+  * Update copyright info
+  * Load modules lazily loaded by datetime.datetime.strptime() when u-u starts
+    When Python is upgraded to a new major version the the version running
+    unattended-upgrades can be removed as being newly unused causing a crash.
+  * Start service after systemd-logind.service to be able to take inhibition lock
+    and handle gracefully when logind is down (LP: #1806487)
+  * List packages making reboot required in /var/run/reboot-required.pkgs
+
+ -- Balint Reczey <rbalint@ubuntu.com>  Mon, 10 Dec 2018 18:11:27 +0100
+
 unattended-upgrades (1.8) unstable; urgency=medium
 
   * Add note about increasing InhibitDelayMaxSec for InstallOnShutdown to

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,8 +2,9 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Source: http://code.launchpad.net/~ubuntu-core-dev/unattended-upgrades/ubuntu
 
 Files: *
-Copyright: © 2005-2014 Michael Vogt <michael.vogt@ubuntu.com>,
-           © 2005-2009 Canonical Ltd
+Copyright: © 2005-2018 Michael Vogt <michael.vogt@ubuntu.com>,
+           © 2017-2018 Balint Reczey <rbalint@ubuntu.com>,
+           © 2005-2018 Canonical Ltd
 License: GPL-2+
   On Debian systems, the complete text of the GNU General Public License
   can be found in </usr/share/common-licenses/GPL-2>.

--- a/debian/tests/upgrade-all-security
+++ b/debian/tests/upgrade-all-security
@@ -61,6 +61,8 @@ chroot_exec "$chroot_dir" apt-get clean
 run_u_u "$chroot_dir"
 
 echo "Checking if there is anything left not upgraded:"
+disable_release_updates "$chroot_dir"
+chroot_exec "$chroot_dir" apt-get update
 chroot_exec "$chroot_dir" apt-get upgrade --with-new-pkgs -s | tee "$chroot_dir/tmp/updates-left"
 
 ! grep "/$distro-security " "$chroot_dir/tmp/updates-left" || (echo "Security upgrades are held back! Exiting..." && exit 1)

--- a/debian/tests/upgrade-all-security
+++ b/debian/tests/upgrade-all-security
@@ -38,7 +38,8 @@ fi
 
 # add package set with many dependencies
 # apt prints "W: APT had planned for dpkg to do more than it reported back" to stderr LP: #1647638
-chroot_exec "$chroot_dir" apt-get install -y xfce4 apparmor 2>&1
+chroot_exec "$chroot_dir" apt-get install -y xfce4 apparmor hello 2>&1
+chroot_exec "$chroot_dir" apt-mark auto hello
 
 # build and install updated python-apt since the one in the snapshot has memory allocation issues
 upgrade_python_apt "$chroot_dir" "$distro"
@@ -67,3 +68,5 @@ chroot_exec "$chroot_dir" apt-get upgrade --with-new-pkgs -s | tee "$chroot_dir/
 
 ! grep "/$distro-security " "$chroot_dir/tmp/updates-left" || (echo "Security upgrades are held back! Exiting..." && exit 1)
 
+echo "Checking if originally auto-removable packages are kept:"
+chroot_exec "$chroot_dir" dpkg -l hello | grep 'ii  hello'

--- a/debian/unattended-upgrades.service
+++ b/debian/unattended-upgrades.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Unattended Upgrades Shutdown
-After=network.target local-fs.target
+After=network.target local-fs.target systemd-logind.service
 RequiresMountsFor=/var/log /var/run /var/lib /boot
 Documentation=man:unattended-upgrade(8)
 

--- a/kernel/postinst.d/unattended-upgrades
+++ b/kernel/postinst.d/unattended-upgrades
@@ -6,5 +6,8 @@ case "$DPKG_MAINTSCRIPT_PACKAGE::$DPKG_MAINTSCRIPT_NAME" in
 esac
 
 if [ -d /var/run ]; then
-   touch /var/run/reboot-required
+    touch /var/run/reboot-required
+    if ! grep -q "^$DPKG_MAINTSCRIPT_PACKAGE$" /var/run/reboot-required.pkgs; then
+        echo "$DPKG_MAINTSCRIPT_PACKAGE" >> /var/run/reboot-required.pkgs
+    fi
 fi

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -48,8 +48,7 @@ class TestRegression(unittest.TestCase):
         options.minimal_upgrade_steps = False
         apt_pkg.config.set("Unattended-Upgrade::MinimalSteps", "False")
         do_install(cache=MockCache(), pkgs_to_upgrade=[pkg],
-                   blacklisted_pkgs=[],
-                   whitelisted_pkgs=[], options=options,
+                   blacklist=[], whitelist=[], options=options,
                    logfile_dpkg=logfile_dpkg)
         # if there is no exception here, we are good
         os.dup2(old_stderr, 2)

--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -35,11 +35,10 @@ class TestRewindCache(unittest.TestCase):
     def test_rewind_cache(self):
         """ Test that rewinding the cache works correctly, debian #743594 """
         options = MockOptions()
-        blacklisted_pkgs = []
-        whitelisted_pkgs = []
+        blacklist = []
+        whitelist = []
         to_upgrade, kept_back = unattended_upgrade.calculate_upgradable_pkgs(
-            self.cache, options, self.allowed_origins, blacklisted_pkgs,
-            whitelisted_pkgs)
+            self.cache, options, self.allowed_origins, blacklist, whitelist)
         self.assertEqual(to_upgrade, [self.cache["test-package"]])
         self.assertEqual(kept_back, ["z-package"])
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1174,8 +1174,8 @@ def send_summary_mail(pkgs,                 # type: List[str]
 
 def do_install(cache,             # type: apt.Cache
                pkgs_to_upgrade,   # type: List[apt.Package]
-               blacklisted_pkgs,  # type: List[str]
-               whitelisted_pkgs,  # type: List[str]
+               blacklist,         # type: List[str]
+               whitelist,         # type: List[str]
                options,           # type: Options
                logfile_dpkg,      # type: str
                ):
@@ -1197,7 +1197,7 @@ def do_install(cache,             # type: apt.Cache
             # try upgrade all "pkgs" in minimal steps
             pkg_install_success = upgrade_in_minimal_steps(
                 cache, [pkg.name for pkg in pkgs_to_upgrade],
-                blacklisted_pkgs, whitelisted_pkgs, logfile_dpkg,
+                blacklist, whitelist, logfile_dpkg,
                 options.verbose or options.debug)
         else:
             pkg_install_success = upgrade_normal(
@@ -1300,12 +1300,12 @@ def _setup_logging(options):
     return mem_log
 
 
-def get_blacklisted_pkgs():
+def get_blacklist():
     # type: () -> List[str]
     return apt_pkg.config.value_list("Unattended-Upgrade::Package-Blacklist")
 
 
-def get_whitelisted_pkgs():
+def get_whitelist():
     # type: () -> List[str]
     return apt_pkg.config.value_list("Unattended-Upgrade::Package-Whitelist")
 
@@ -1368,8 +1368,8 @@ def try_to_upgrade(pkg,               # type: apt.Package
                    pkgs_kept_back,    # type: List[str]
                    cache,             # type: apt.Cache
                    allowed_origins,   # type: List[str]
-                   blacklisted_pkgs,  # type: List[str]
-                   whitelisted_pkgs,  # type: List[str]
+                   blacklist,         # type: List[str]
+                   whitelist,         # type: List[str]
                    ):
     # type: (...) -> None
     try:
@@ -1383,9 +1383,8 @@ def try_to_upgrade(pkg,               # type: apt.Package
             return
         cache._cached_candidate_pkgnames.add(pkg.name)
         cache.mark_upgrade_adjusted(pkg, from_user=not pkg.is_auto_installed)
-        if check_changes_for_sanity(cache, allowed_origins,
-                                    blacklisted_pkgs, whitelisted_pkgs,
-                                    pkg):
+        if check_changes_for_sanity(cache, allowed_origins, blacklist,
+                                    whitelist, pkg):
             # add to packages to upgrade
             pkgs_to_upgrade.append(pkg)
             # re-eval pkgs_kept_back as the resolver may fail to
@@ -1412,8 +1411,8 @@ def try_to_upgrade(pkg,               # type: apt.Package
 def calculate_upgradable_pkgs(cache,             # type: apt.Cache
                               options,           # type: Options
                               allowed_origins,   # type: List[str]
-                              blacklisted_pkgs,  # type: List[str]
-                              whitelisted_pkgs,  # type: List[str]
+                              blacklist,         # type: List[str]
+                              whitelist,         # type: List[str]
                               ):
     # type: (...) -> Tuple[List[apt.Package], List[str]]
     pkgs_to_upgrade = []  # type: List[apt.Package]
@@ -1426,7 +1425,7 @@ def calculate_upgradable_pkgs(cache,             # type: apt.Cache
                 pkg.name, getattr(pkg.candidate, "origins", [])))
 
         if (pkg.is_upgradable
-                and is_pkgname_in_whitelist(pkg.name, whitelisted_pkgs)):
+                and is_pkgname_in_whitelist(pkg.name, whitelist)):
             try:
                 ver_in_allowed_origin(pkg, allowed_origins)
             except NoAllowedOriginError:
@@ -1437,8 +1436,8 @@ def calculate_upgradable_pkgs(cache,             # type: apt.Cache
                            pkgs_kept_back,
                            cache,
                            allowed_origins,
-                           blacklisted_pkgs,
-                           whitelisted_pkgs)
+                           blacklist,
+                           whitelist)
 
     if cache.get_changes():
         cache.clear()
@@ -1482,8 +1481,7 @@ def get_auto_removable(cache):
             if pkg.is_auto_removable}
 
 
-def is_autoremove_valid(cache, pkgname, auto_removable, blacklisted_pkgs,
-                        whitelisted_pkgs):
+def is_autoremove_valid(cache, pkgname, auto_removable, blacklist, whitelist):
     # type: (apt.Cache, str, AbstractSet[str], List[str], List[str]) -> bool
     changes = cache.get_changes()
     if not changes:
@@ -1491,7 +1489,7 @@ def is_autoremove_valid(cache, pkgname, auto_removable, blacklisted_pkgs,
         return True
     pkgnames = {pkg.name for pkg in changes}
     for pkg in changes:
-        if not is_pkg_change_allowed(pkg, blacklisted_pkgs, whitelisted_pkgs):
+        if not is_pkg_change_allowed(pkg, blacklist, whitelist):
             logging.warning(
                 _("Keeping the following auto-removable package(s) because "
                   "they include %s which is set to be kept unmodified: %s"),
@@ -1527,8 +1525,8 @@ def do_auto_remove(cache,             # type: apt.Cache
                    auto_removable,    # type: AbstractSet[str]
                    logfile_dpkg,      # type: str
                    minimal_steps,     # type: bool
-                   blacklisted_pkgs,  # type: List[str]
-                   whitelisted_pkgs,  # type: List[str]
+                   blacklist,         # type: List[str]
+                   whitelist,         # type: List[str]
                    verbose=False,     # type: bool
                    dry_run=False      # type: bool
                    ):
@@ -1549,7 +1547,7 @@ def do_auto_remove(cache,             # type: apt.Cache
                 continue
             cache[pkgname].mark_delete()
             if not is_autoremove_valid(cache, pkgname, auto_removable,
-                                       blacklisted_pkgs, whitelisted_pkgs):
+                                       blacklist, whitelist):
                 # this situation can occur when removing newly unused packages
                 # would also remove old unused packages which are not set
                 # for removal, thus getting there is not handled as an error
@@ -1568,8 +1566,8 @@ def do_auto_remove(cache,             # type: apt.Cache
     else:
         for pkgname in auto_removable:
             cache[pkgname].mark_delete()
-        if is_autoremove_valid(cache, "", auto_removable, blacklisted_pkgs,
-                               whitelisted_pkgs):
+        if is_autoremove_valid(cache, "", auto_removable, blacklist,
+                               whitelist):
             # do it in one step
             if not dry_run:
                 res, error = cache_commit(cache, logfile_dpkg, verbose)
@@ -1741,14 +1739,14 @@ def run(options,             # type: Options
     allowed_origins = get_allowed_origins()
 
     # pkgs that are (for some reason) not safe to install
-    blacklisted_pkgs = get_blacklisted_pkgs()
-    logging.info(_("Initial blacklisted packages: %s"),
-                 " ".join(blacklisted_pkgs))
+    blacklist = get_blacklist()
+    logging.info(_("Initial blacklist : %s"),
+                 " ".join(blacklist))
 
     # install only these packages regardless of other upgrades available
-    whitelisted_pkgs = get_whitelisted_pkgs()
-    logging.info(_("Initial whitelisted packages: %s"),
-                 " ".join(whitelisted_pkgs))
+    whitelist = get_whitelist()
+    logging.info(_("Initial whitelist: %s"),
+                 " ".join(whitelist))
 
     logging.info(_("Starting unattended upgrades script"))
 
@@ -1821,7 +1819,7 @@ def run(options,             # type: Options
 
     # find out about the packages that are upgradable (in an allowed_origin)
     pkgs_to_upgrade, pkgs_kept_back = calculate_upgradable_pkgs(
-        cache, options, allowed_origins, blacklisted_pkgs, whitelisted_pkgs)
+        cache, options, allowed_origins, blacklist, whitelist)
     pkgs_to_upgrade.sort(key=lambda p: p.name)
     pkgs = [pkg.name for pkg in pkgs_to_upgrade]
     logging.debug("pkgs that look like they should be upgraded: %s"
@@ -1886,7 +1884,9 @@ def run(options,             # type: Options
             if not item.is_trusted and not apt_pkg.config.find_b(
                     "APT::Get::AllowUnauthenticated", False):
                 logging.debug("%s is blacklisted because it is not trusted")
-                blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
+                pkg_name = pkgname_from_deb(item.destfile)
+                if not is_pkgname_in_blacklist(pkg_name, blacklist):
+                    blacklist.append("%s$" % re.escape(pkg_name))
             if not is_deb(item.destfile):
                 logging.debug("%s is not a .deb file" % item)
                 continue
@@ -1906,17 +1906,19 @@ def run(options,             # type: Options
                 logging.warning(_("Package %s has conffile prompt and "
                                   "needs to be upgraded manually"),
                                 pkgname_from_deb(item.destfile))
-                blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
-                pkgs_kept_back.append(pkgname_from_deb(item.destfile))
+                pkg_name = pkgname_from_deb(item.destfile)
+                if not is_pkgname_in_blacklist(pkg_name, blacklist):
+                    blacklist.append("%s$" % re.escape(pkg_name))
+                pkgs_kept_back.append(pkgname_from_deb(pkg_name))
                 pkg_conffile_prompt = True
 
         # redo the selection about the packages to upgrade based on the new
         # blacklist
-        logging.debug("blacklist: %s" % blacklisted_pkgs)
+        logging.debug("blacklist: %s" % blacklist)
         # whitelist
-        logging.debug("whitelist: %s" % whitelisted_pkgs)
+        logging.debug("whitelist: %s" % whitelist)
         # find out about the packages that are upgradable (in a allowed_origin)
-        if len(blacklisted_pkgs) > 0 or len(whitelisted_pkgs) > 0:
+        if len(blacklist) > 0 or len(whitelist) > 0:
             if cache.get_changes():
                 cache.clear()
             old_pkgs_to_upgrade = pkgs_to_upgrade[:]
@@ -1928,8 +1930,8 @@ def run(options,             # type: Options
                     pkg, from_user=not pkg.is_auto_installed)
                 if check_changes_for_sanity(cache,
                                             allowed_origins,
-                                            blacklisted_pkgs,
-                                            whitelisted_pkgs):
+                                            blacklist,
+                                            whitelist):
                     pkgs_to_upgrade.append(pkg)
                 else:
                     if not (pkg.name in pkgs_kept_back):
@@ -1966,9 +1968,8 @@ def run(options,             # type: Options
             (kernel_pkgs_remove_success,
              kernel_pkgs_removed,
              kernel_pkgs_kept_installed) = do_auto_remove(
-                cache, auto_removable_kernel_pkgs,
-                logfile_dpkg, options.minimal_upgrade_steps,
-                blacklisted_pkgs, whitelisted_pkgs,
+                cache, auto_removable_kernel_pkgs, logfile_dpkg,
+                options.minimal_upgrade_steps, blacklist, whitelist,
                 options.verbose or options.debug, options.dry_run)
             auto_removable = get_auto_removable(cache)
 
@@ -2018,8 +2019,8 @@ def run(options,             # type: Options
         # do install
         pkg_install_success = do_install(cache,
                                          pkgs_to_upgrade,
-                                         blacklisted_pkgs,
-                                         whitelisted_pkgs,
+                                         blacklist,
+                                         whitelist,
                                          options,
                                          logfile_dpkg)
     # Was the overall run succesful: only if everything installed
@@ -2046,8 +2047,7 @@ def run(options,             # type: Options
          pkgs_removed,
          pkgs_kept_installed) = do_auto_remove(
             cache, auto_removals, logfile_dpkg, options.minimal_upgrade_steps,
-            blacklisted_pkgs, whitelisted_pkgs,
-            options.verbose or options.debug,
+            blacklist, whitelist, options.verbose or options.debug,
             options.dry_run)
         successful_run = successful_run and pkg_remove_success
     # the user wants *only new* auto-removals to be removed
@@ -2060,8 +2060,7 @@ def run(options,             # type: Options
          pkgs_removed,
          pkgs_kept_installed) = do_auto_remove(
             cache, auto_removals, logfile_dpkg, options.minimal_upgrade_steps,
-            blacklisted_pkgs, whitelisted_pkgs,
-            options.verbose or options.debug,
+            blacklist, whitelist, options.verbose or options.debug,
             options.dry_run)
         successful_run = successful_run and pkg_remove_success
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -629,16 +629,6 @@ def upgrade_normal(cache, logfile_dpkg, verbose):
     return res
 
 
-def use_minimal_steps(options):
-    # type: (Options) -> bool
-    # COMPAT with the mispelling
-    return (options.minimal_upgrade_steps
-            or (apt_pkg.config.find_b("Unattended-Upgrades::MinimalSteps",
-                                      True)
-                and apt_pkg.config.find_b("Unattended-Upgrade::MinimalSteps",
-                                          True)))
-
-
 def upgrade_in_minimal_steps(cache,            # type: apt.Cache
                              pkgs_to_upgrade,  # type: List[str]
                              blacklist,        # type: List[str]
@@ -1203,7 +1193,7 @@ def do_install(cache,             # type: apt.Cache
 
     pkg_install_success = False
     try:
-        if use_minimal_steps(options):
+        if options.minimal_upgrade_steps:
             # try upgrade all "pkgs" in minimal steps
             pkg_install_success = upgrade_in_minimal_steps(
                 cache, [pkg.name for pkg in pkgs_to_upgrade],
@@ -1975,7 +1965,7 @@ def run(options,             # type: Options
              kernel_pkgs_removed,
              kernel_pkgs_kept_installed) = do_auto_remove(
                 cache, auto_removable_kernel_pkgs,
-                logfile_dpkg, use_minimal_steps(options),
+                logfile_dpkg, options.minimal_upgrade_steps,
                 blacklisted_pkgs, whitelisted_pkgs,
                 options.verbose or options.debug, options.dry_run)
             auto_removable = get_auto_removable(cache)
@@ -2053,7 +2043,7 @@ def run(options,             # type: Options
         (pkg_remove_success,
          pkgs_removed,
          pkgs_kept_installed) = do_auto_remove(
-            cache, auto_removals, logfile_dpkg, use_minimal_steps(options),
+            cache, auto_removals, logfile_dpkg, options.minimal_upgrade_steps,
             blacklisted_pkgs, whitelisted_pkgs,
             options.verbose or options.debug,
             options.dry_run)
@@ -2067,7 +2057,7 @@ def run(options,             # type: Options
         (pkg_remove_success,
          pkgs_removed,
          pkgs_kept_installed) = do_auto_remove(
-            cache, auto_removals, logfile_dpkg, use_minimal_steps(options),
+            cache, auto_removals, logfile_dpkg, options.minimal_upgrade_steps,
             blacklisted_pkgs, whitelisted_pkgs,
             options.verbose or options.debug,
             options.dry_run)
@@ -2115,6 +2105,11 @@ if __name__ == "__main__":
     # this ensures the commandline is logged in /var/log/apt/history.log
     apt_pkg.config.set("Commandline::AsString", " ".join(sys.argv))
 
+    # COMPAT with the mispelling
+    minimal_steps_default = (
+        apt_pkg.config.find_b("Unattended-Upgrades::MinimalSteps", True)
+        and apt_pkg.config.find_b("Unattended-Upgrade::MinimalSteps", True))
+
     # init the options
     parser = OptionParser()
     parser.add_option("-d", "--debug",
@@ -2137,13 +2132,18 @@ if __name__ == "__main__":
                       action="store_true", default=False,
                       help=_("Only download, do not even try to install."))
     parser.add_option("", "--minimal-upgrade-steps",
-                      action="store_true", default=False,
+                      action="store_true", default=minimal_steps_default,
+                      help=_("Upgrade in minimal steps (and allow "
+                             "interrupting with SIGTERM) (default)"))
+    parser.add_option("", "--no-minimal-upgrade-steps",
+                      action="store_false", default=minimal_steps_default,
+                      dest="minimal_upgrade_steps",
                       help=_("Upgrade in minimal steps (and allow "
                              "interrupting with SIGTERM"))
     parser.add_option("", "--minimal_upgrade_steps",
                       action="store_true",
                       help=SUPPRESS_HELP,
-                      default=False)
+                      default=minimal_steps_default)
     options = cast(Options, (parser.parse_args())[0])
 
     if os.getuid() != 0:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1449,6 +1449,10 @@ def calculate_upgradable_pkgs(cache,             # type: apt.Cache
                            allowed_origins,
                            blacklisted_pkgs,
                            whitelisted_pkgs)
+
+    if cache.get_changes():
+        cache.clear()
+
     return pkgs_to_upgrade, pkgs_kept_back
 
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
-# Copyright (c) 2005-2015 Canonical Ltd
+# Copyright (c) 2005-2018 Canonical Ltd
 #
 # AUTHOR:
 # Michael Vogt <mvo@ubuntu.com>
-#
+# Balint Reczey <rbalint@ubuntu.com>
+
 # This file is part of unattended-upgrades
 #
 # unattended-upgrades is free software; you can redistribute it and/or

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1925,7 +1925,8 @@ def run(options,             # type: Options
         logging.debug("whitelist: %s" % whitelisted_pkgs)
         # find out about the packages that are upgradable (in a allowed_origin)
         if len(blacklisted_pkgs) > 0 or len(whitelisted_pkgs) > 0:
-            cache.clear()
+            if cache.get_changes():
+                cache.clear()
             old_pkgs_to_upgrade = pkgs_to_upgrade[:]
             pkgs_to_upgrade = []
             for pkg in old_pkgs_to_upgrade:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1883,7 +1883,9 @@ def run(options,             # type: Options
                 return UnattendedUpgradesResult(
                     False, (_("Download finished, but file %s not there?!?") %
                             item.destfile))
-            if not item.is_trusted:
+            if not item.is_trusted and not apt_pkg.config.find_b(
+                    "APT::Get::AllowUnauthenticated", False):
+                logging.debug("%s is blacklisted because it is not trusted")
                 blacklisted_pkgs.append(pkgname_from_deb(item.destfile))
             if not is_deb(item.destfile):
                 logging.debug("%s is not a .deb file" % item)

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -141,6 +141,9 @@ class UnattendedUpgradesCache(apt.Cache):
         self.allowed_origins = allowed_origins
         apt.Cache.__init__(self, rootdir=rootdir)
 
+        # pre-heat lazy-loaded modules to avoid crash on python upgrade
+        datetime.datetime.strptime("", "")
+
         # generate versioned_kernel_pkgs_regexp for later use
         apt_versioned_kernel_pkgs = apt_pkg.config.value_list(
             "APT::VersionedKernelPackages")

--- a/unattended-upgrade-shutdown
+++ b/unattended-upgrade-shutdown
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
-# Copyright (c) 2009 Canonical Ltd
+# Copyright (c) 2009-2018 Canonical Ltd
 #
 # AUTHOR:
 # Michael Vogt <mvo@ubuntu.com>
+# Balint Reczey <rbalint@ubuntu.com>
 #
 # unattended-upgrade-shutdown - helper that checks if a
 # unattended-upgrade is in progress and waits until it exists

--- a/unattended-upgrade-shutdown
+++ b/unattended-upgrade-shutdown
@@ -106,37 +106,6 @@ def signal_stop_unattended_upgrade():
                           "already stopped")
 
 
-def get_logind_proxy():
-    """ Get logind dbus proxy object """
-    bus = dbus.SystemBus()
-    return bus.get_object(
-        'org.freedesktop.login1', '/org/freedesktop/login1')
-
-
-def get_inhibit_shutdown_lock(logind_proxy):
-    """ Take delay inhibitor lock """
-    try:
-        logind_manager = dbus.Interface(
-            logind_proxy, dbus_interface='org.freedesktop.login1.Manager')
-        return logind_manager.Inhibit(
-            "shutdown", "Unattended Upgrades Shutdown",
-            _("Stop ongoing upgrades or perform upgrades before shutdown"),
-            "delay")
-    except Exception:
-        logging.warning("Could not get delay inhibitor lock")
-
-
-def get_inhibit_max_delay(logind_proxy):
-    try:
-        getter_interface = dbus.Interface(
-            logind_proxy, dbus_interface='org.freedesktop.DBus.Properties')
-        return (getter_interface.Get(
-            "org.freedesktop.login1.Manager", "InhibitDelayMaxUSec")
-                / (1000 * 1000))
-    except Exception:
-        return 3
-
-
 def exit_log_result(success):
     if success:
         log_msg(_("All upgrades installed"), logging.INFO)
@@ -155,6 +124,7 @@ class UnattendedUpgradesShutdown():
         self.max_delay = options.delay * 60
         self.iter_timer_set = False
         self.apt_pkg_reinit_done = None
+        self.shutdown_pending = False
         self.on_shutdown_mode = None
         self.on_shutdown_mode_uu_proc = None
         self.start_time = None
@@ -166,18 +136,60 @@ class UnattendedUpgradesShutdown():
             DBusGMainLoop(set_as_default=True)
         except NameError:
             pass
-        self.logind_proxy = get_logind_proxy()
-        self.wait_period = min(3, get_inhibit_max_delay(self.logind_proxy) / 3)
-        self.inhibit_lock = get_inhibit_shutdown_lock(self.logind_proxy)
+        try:
+            self.inhibit_lock = self.get_inhibit_shutdown_lock()
+        except dbus.exceptions.DBusException:
+            logging.warning("Could not get delay inhibitor lock")
+            self.inhibit_lock = None
+        self.logind_proxy = None
+        self.wait_period = min(3, self.get_inhibit_max_delay() / 3)
         self.preparing_for_shutdown = False
+
+    def get_logind_proxy(self):
+        """ Get logind dbus proxy object """
+        if not self.logind_proxy:
+            bus = dbus.SystemBus()
+            if self.inhibit_lock is None:
+                # try to get inhibit_lock or throw exception quickly when
+                # logind is down
+                self.inhibit_lock = self.get_inhibit_shutdown_lock()
+            self.logind_proxy = bus.get_object(
+                'org.freedesktop.login1', '/org/freedesktop/login1')
+        return self.logind_proxy
+
+    def get_inhibit_shutdown_lock(self):
+        """ Take delay inhibitor lock """
+        bus = dbus.SystemBus()
+        return bus.call_blocking(
+            'org.freedesktop.login1', '/org/freedesktop/login1',
+            'org.freedesktop.login1.Manager', 'Inhibit', 'ssss',
+            ('shutdown', 'Unattended Upgrades Shutdown',
+             _('Stop ongoing upgrades or perform upgrades before shutdown'),
+             'delay'), timeout=2.0)
+
+    def get_inhibit_max_delay(self):
+        try:
+            logind_proxy = self.get_logind_proxy()
+            getter_interface = dbus.Interface(
+                logind_proxy,
+                dbus_interface='org.freedesktop.DBus.Properties')
+            return (getter_interface.Get(
+                "org.freedesktop.login1.Manager", "InhibitDelayMaxUSec")
+                    / (1000 * 1000))
+        except dbus.exceptions.DBusException:
+            return 3
 
     def is_preparing_for_shutdown(self):
         if not self.shutdown_pending:
-            getter_interface = dbus.Interface(
-                self.logind_proxy,
-                dbus_interface='org.freedesktop.DBus.Properties')
-            self.shutdown_pending = getter_interface.Get(
-                "org.freedesktop.login1.Manager", "PreparingForShutdown")
+            try:
+                logind_proxy = self.get_logind_proxy()
+                getter_interface = dbus.Interface(
+                    logind_proxy,
+                    dbus_interface='org.freedesktop.DBus.Properties')
+                self.shutdown_pending = getter_interface.Get(
+                    "org.freedesktop.login1.Manager", "PreparingForShutdown")
+            except dbus.exceptions.DBusException:
+                return False
         return self.shutdown_pending
 
     def start_iterations(self):
@@ -188,6 +200,30 @@ class UnattendedUpgradesShutdown():
                 GLib.timeout_add(0, lambda: self.iter() and False)
             except NameError:
                 pass
+
+    def run_polling(self, signal_handler):
+        logging.warning(
+            _("Unable to monitor PrepareForShutdown() signal, polling "
+              "instead."))
+        logging.warning(
+            _("To enable monitoring the PrepareForShutdown() signal "
+              "instead of polling please install the python3-gi package"))
+
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGHUP, signal_handler)
+
+        # poll for PrepareForShutdown then run final iterations
+        if self.options.wait_for_signal:
+            logging.debug("Waiting for signal to start operation ")
+            while (not self.stop_signal_received.is_set()
+                   and not self.is_preparing_for_shutdown()):
+                self.stop_signal_received.wait(self.wait_period)
+        else:
+            logging.debug("Skip waiting for signals, starting operation "
+                          "now")
+        while not self.iter():
+            # TODO iter on sigterm and sighup, too
+            time.sleep(self.wait_period)
 
     def run(self):
         """ delay shutdown and wait for PrepareForShutdown or other signals"""
@@ -201,53 +237,43 @@ class UnattendedUpgradesShutdown():
             self.stop_signal_received.set()
             self.start_iterations()
 
-        # wait for signals
+        # fall back to polling without GLib
         try:
             hasattr(GLib, "MainLoop")
-            for sig in (signal.SIGTERM, signal.SIGHUP):
-                GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, sig,
-                                     signal_handler, None, None)
-            if self.options.wait_for_signal:
-                def prepare_for_shutdown_handler(active):
-                    """ Handle PrepareForShutdown() """
-                    if not active:
-                        logging.warning("PrepareForShutdown(false) received, "
-                                        "this should not happen")
-                    # PrepareForShutdown arrived, starting final iterations
-                    self.start_iterations()
-                self.logind_proxy.connect_to_signal(
-                    "PrepareForShutdown", prepare_for_shutdown_handler)
-                logging.debug("Waiting for signal to start operation ")
-            else:
-                # starting final iterations immediately
-                logging.debug("Skip waiting for signals, starting operation "
-                              "now")
-                self.start_iterations()
-            GLib.MainLoop().run()
-
         except NameError:
-            logging.warning(
-                _("Unable to monitor PrepareForShutdown() signal, polling "
-                  "instead."))
-            logging.warning(
-                _("To enable monitoring the PrepareForShutdown() signal "
-                  "instead of polling please install the python3-gi package"))
+            self.run_polling(signal_handler)
+            return
 
-            signal.signal(signal.SIGTERM, signal_handler)
-            signal.signal(signal.SIGHUP, signal_handler)
+        for sig in (signal.SIGTERM, signal.SIGHUP):
+            GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, sig,
+                                 signal_handler, None, None)
+        if self.options.wait_for_signal:
+            def prepare_for_shutdown_handler(active):
+                """ Handle PrepareForShutdown() """
+                if not active:
+                    logging.warning("PrepareForShutdown(false) received, "
+                                    "this should not happen")
+                # PrepareForShutdown arrived, starting final iterations
+                self.start_iterations()
+            try:
+                self.get_logind_proxy().connect_to_signal(
+                    "PrepareForShutdown", prepare_for_shutdown_handler)
+            except dbus.exceptions.DBusException:
+                logging.warning(
+                    _("Unable to monitor PrepareForShutdown() signal, polling "
+                      "instead."))
+                logging.warning(
+                    _("Maybe systemd-logind service is not running."))
+                self.run_polling(signal_handler)
+                return
 
-            # poll for PrepareForShutdown then run final iterations
-            if self.options.wait_for_signal:
-                logging.debug("Waiting for signal to start operation ")
-                while (not self.stop_signal_received.is_set()
-                       and not self.is_preparing_for_shutdown()):
-                    self.stop_signal_received.wait(self.wait_period)
-            else:
-                logging.debug("Skip waiting for signals, starting operation "
-                              "now")
-            while not self.iter():
-                # TODO iter on sigterm and sighup, too
-                time.sleep(self.wait_period)
+            logging.debug("Waiting for signal to start operation ")
+        else:
+            # starting final iterations immediately
+            logging.debug("Skip waiting for signals, starting operation "
+                          "now")
+            self.start_iterations()
+        GLib.MainLoop().run()
 
     def try_iter_on_shutdown(self):
         # check if we need to run unattended-upgrades on shutdown and if


### PR DESCRIPTION
When collecting upgradable packages the upgradable ones stayed in the
cache and they were upgraded together even when unattended-upgrades
was configured to perform upgrades in minimal steps.