### PR TITLE
Fix the positive test case for test-dev-release

### DIFF
--- a/test/test_dev_release.py
+++ b/test/test_dev_release.py
@@ -142,8 +142,7 @@ Unattended-Upgrade::OnlyOnAcPower "false";
         # read the log to see what happend
         with open(self.log) as f:
             # Check that we could have run
-            needle = ("Lock could not be acquired "
-                      "(another package manager running?)")
+            needle = "Running on the development release"
             haystack = f.read()
             self.assertTrue(needle in haystack,
                             "Can not find '%s' in '%s'" % (needle, haystack))
@@ -162,8 +161,7 @@ Unattended-Upgrade::OnlyOnAcPower "false";
         # read the log to see what happend
         with open(self.log) as f:
             # Check that we could have run
-            needle = ("Lock could not be acquired "
-                      "(another package manager running?)")
+            needle = "Running on the development release"
             haystack = f.read()
             self.assertTrue(needle in haystack,
                             "Can not find '%s' in '%s'" % (needle, haystack))

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1736,6 +1736,8 @@ def run(options,             # type: Options
                                 (devel.release - DEVEL_UNTIL_RELEASE
                                  - datetime.timedelta(days=1)))
                 return UnattendedUpgradesResult(True)
+
+            logging.debug("Running on the development release")
     elif "(development branch)" in DISTRO_DESC and not\
             apt_pkg.config.find_b("Unattended-Upgrade::DevRelease", True):
         syslog.syslog(_("Not running on the development release."))


### PR DESCRIPTION
Add a new message stating that we are running on the devel
release, and check for its existence. The message is awfully
similar to the "Not running" messages, though, might want to
improve that a bit