### PR TITLE
Auto-retrieve repositories to be updated

### DIFF
--- a/debian/listMissingRepos.py
+++ b/debian/listMissingRepos.py
@@ -94,4 +94,5 @@ with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
 ## Report repositories that can be added to /etc/apt/apt.conf.d/50unattended-upgrades
 for repoFound in repos_to_add:
     if repoFound not in repos_already_present:
-         print repoFound
+         print(repoFound)
+ 

--- a/debian/listMissingRepos.py
+++ b/debian/listMissingRepos.py
@@ -29,8 +29,8 @@ for release_file in release_files:
     origin_string = re.findall(ORIGIN_PATTERN, read_data)
     suite_string = re.findall(SUITE_PATTERN, read_data)
     try:
-        repo = "\"%s:%s\";" % (origin_string[0].replace(',', r'\,'), 
-            suite_string[0].replace(',', r'\,'))
+        repo = "\"%s:%s\";" % (origin_string[0].replace(',', r'\,'),
+                    suite_string[0].replace(',', r'\,'))
         if re.match(regex_url, origin_string[0]):
             skipped_release_files.append(release_file)
         else:
@@ -54,4 +54,4 @@ with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
 # Report repositories that can be added to config file
 for repoFound in repos_to_add:
     if repoFound not in repos_already_present:
-        print repoFound
+        print(repoFound)

--- a/debian/listMissingRepos.py
+++ b/debian/listMissingRepos.py
@@ -1,8 +1,10 @@
 # Adapted from work of Abhishek Bathia
 
-import os, re, platform
+import os
+import re
+import platform
 
-## Get the repos
+# Get the repos
 PATH = '/var/lib/apt/lists/'
 files = os.listdir(PATH)
 release_files = [file for file in files if file.endswith('Release')]
@@ -10,89 +12,46 @@ release_files = [file for file in files if file.endswith('Release')]
 ORIGIN_PATTERN = re.compile('Origin: (.*)\n')
 SUITE_PATTERN = re.compile('Suite: (.*)\n')
 regex_url = re.compile(
-        r'^(?:http|ftp)s?://' # http:// or https://
-        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
-        r'localhost|' #localhost...
-        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
-        r'(?::\d+)?' # optional port
-        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+    r'^(?:http|ftp)s?://'  # http:// or https://
+    r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+\
+            (?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
+    r'localhost|'  # localhost...
+    r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
+    r'(?::\d+)?'  # optional port
+    r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 
 skipped_release_files = []
 repos_to_add = []
 for release_file in release_files:
-  with open(PATH + release_file, 'r') as f:
-    read_data = f.read()
+    with open(PATH + release_file, 'r') as f:
+        read_data = f.read()
     # parse to get origin and suite
     origin_string = re.findall(ORIGIN_PATTERN, read_data)
     suite_string = re.findall(SUITE_PATTERN, read_data)
     try:
-      repo = "\"%s:%s\";" %(origin_string[0].replace(',',r'\,'),
-                            suite_string[0].replace(',',r'\,'))
-      if re.match(regex_url, origin_string[0]):
-        skipped_release_files.append(release_file)
-      else:
-        repos_to_add.append(repo)
+        repo = "\"%s:%s\";" % (origin_string[0].replace(',', r'\,'), 
+            suite_string[0].replace(',', r'\,'))
+        if re.match(regex_url, origin_string[0]):
+            skipped_release_files.append(release_file)
+        else:
+            repos_to_add.append(repo)
     except IndexError:
-      skipped_release_files.append(release_file)
+        skipped_release_files.append(release_file)
 
-## Checking if repos_to_add not already present  in /etc/apt/apt.conf.d/50unattended-upgrades
+# Checking if repos_to_add not already present in
+# /etc/apt/apt.conf.d/50unattended-upgrades
 with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
-  read_data = f.read()
-  # get everything before first };
-  raw_data = re.findall('[.\s\S]*};', read_data)
-  # replace linux placeholders
-  distro_id, _, distro_codename = platform.linux_distribution()
-  clean_data = raw_data[0].replace("${distro_id}",distro_id).replace("${distro_codename}",distro_codename)
-  repos_already_present = re.findall('".*:.*";', clean_data)
-# Adapted from work of Abhishek Bathia
-
-import os, re, platform
-
-## Get the repos
-PATH = '/var/lib/apt/lists/'
-files = os.listdir(PATH)
-release_files = [file for file in files if file.endswith('Release')]
-
-ORIGIN_PATTERN = re.compile('Origin: (.*)\n')
-SUITE_PATTERN = re.compile('Suite: (.*)\n')
-regex_url = re.compile(
-        r'^(?:http|ftp)s?://' # http:// or https://
-        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
-        r'localhost|' #localhost...
-        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
-        r'(?::\d+)?' # optional port
-        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
-
-skipped_release_files = []
-repos_to_add = []
-for release_file in release_files:
-  with open(PATH + release_file, 'r') as f:
     read_data = f.read()
-    # parse to get origin and suite
-    origin_string = re.findall(ORIGIN_PATTERN, read_data)
-    suite_string = re.findall(SUITE_PATTERN, read_data)
-    try:
-      repo = "\"%s:%s\";" %(origin_string[0].replace(',',r'\,'),
-                            suite_string[0].replace(',',r'\,'))
-      if re.match(regex_url, origin_string[0]):
-        skipped_release_files.append(release_file)
-      else:
-        repos_to_add.append(repo)
-    except IndexError:
-      skipped_release_files.append(release_file)
+    # get everything before first };
+    raw_data = re.findall('[.\s\S]*};', read_data)
+    # replace linux placeholders
+    distro_id, _, distro_codename = platform.linux_distribution()
+    clean_data = raw_data[0].replace("${distro_id}", distro_id) \
+        .replace("${distro_codename}", distro_codename)
+    repos_already_present = re.findall('".*:.*";', clean_data)
 
-## Checking if repos_to_add not already present  in /etc/apt/apt.conf.d/50unattended-upgrades
-with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
-  read_data = f.read()
-  # get everything before first };
-  raw_data = re.findall('[.\s\S]*};', read_data)
-  # replace linux placeholders
-  distro_id, _, distro_codename = platform.linux_distribution()
-  clean_data = raw_data[0].replace("${distro_id}",distro_id).replace("${distro_codename}",distro_codename)
-  repos_already_present = re.findall('".*:.*";', clean_data)
 
-## Report repositories that can be added to /etc/apt/apt.conf.d/50unattended-upgrades
+# Report repositories that can be added to config file
 for repoFound in repos_to_add:
     if repoFound not in repos_already_present:
-         print(repoFound)
- 
+        print repoFound

--- a/debian/listMissingRepos.py
+++ b/debian/listMissingRepos.py
@@ -1,8 +1,6 @@
 # Adapted from work of Abhishek Bathia
 
-import os, re, pdb, platform
-from pprint import pprint
-
+import os, re, platform
 
 ## Get the repos
 PATH = '/var/lib/apt/lists/'

--- a/debian/listMissingRepos.py
+++ b/debian/listMissingRepos.py
@@ -44,6 +44,54 @@ with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
   distro_id, _, distro_codename = platform.linux_distribution()
   clean_data = raw_data[0].replace("${distro_id}",distro_id).replace("${distro_codename}",distro_codename)
   repos_already_present = re.findall('".*:.*";', clean_data)
+# Adapted from work of Abhishek Bathia
 
-repos_to_add = [repo for repo in repos_to_add if repo not in repos_already_present]
-print ('\n'.join(repos_to_add))
+import os, re, platform
+
+## Get the repos
+PATH = '/var/lib/apt/lists/'
+files = os.listdir(PATH)
+release_files = [file for file in files if file.endswith('Release')]
+
+ORIGIN_PATTERN = re.compile('Origin: (.*)\n')
+SUITE_PATTERN = re.compile('Suite: (.*)\n')
+regex_url = re.compile(
+        r'^(?:http|ftp)s?://' # http:// or https://
+        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
+        r'localhost|' #localhost...
+        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
+        r'(?::\d+)?' # optional port
+        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+
+skipped_release_files = []
+repos_to_add = []
+for release_file in release_files:
+  with open(PATH + release_file, 'r') as f:
+    read_data = f.read()
+    # parse to get origin and suite
+    origin_string = re.findall(ORIGIN_PATTERN, read_data)
+    suite_string = re.findall(SUITE_PATTERN, read_data)
+    try:
+      repo = "\"%s:%s\";" %(origin_string[0].replace(',',r'\,'),
+                            suite_string[0].replace(',',r'\,'))
+      if re.match(regex_url, origin_string[0]):
+        skipped_release_files.append(release_file)
+      else:
+        repos_to_add.append(repo)
+    except IndexError:
+      skipped_release_files.append(release_file)
+
+## Checking if repos_to_add not already present  in /etc/apt/apt.conf.d/50unattended-upgrades
+with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
+  read_data = f.read()
+  # get everything before first };
+  raw_data = re.findall('[.\s\S]*};', read_data)
+  # replace linux placeholders
+  distro_id, _, distro_codename = platform.linux_distribution()
+  clean_data = raw_data[0].replace("${distro_id}",distro_id).replace("${distro_codename}",distro_codename)
+  repos_already_present = re.findall('".*:.*";', clean_data)
+
+## Report repositories that can be added to /etc/apt/apt.conf.d/50unattended-upgrades
+for repoFound in repos_to_add:
+    if repoFound not in repos_already_present:
+         print repoFound

--- a/debian/listMissingRepos.py
+++ b/debian/listMissingRepos.py
@@ -30,7 +30,7 @@ for release_file in release_files:
     suite_string = re.findall(SUITE_PATTERN, read_data)
     try:
         repo = "\"%s:%s\";" % (origin_string[0].replace(',', r'\,'),
-                    suite_string[0].replace(',', r'\,'))
+                               suite_string[0].replace(',', r'\,'))
         if re.match(regex_url, origin_string[0]):
             skipped_release_files.append(release_file)
         else:

--- a/debian/listMissingRepos.py
+++ b/debian/listMissingRepos.py
@@ -1,0 +1,51 @@
+# Adapted from work of Abhishek Bathia
+
+import os, re, pdb, platform
+from pprint import pprint
+
+
+## Get the repos
+PATH = '/var/lib/apt/lists/'
+files = os.listdir(PATH)
+release_files = [file for file in files if file.endswith('Release')]
+
+ORIGIN_PATTERN = re.compile('Origin: (.*)\n')
+SUITE_PATTERN = re.compile('Suite: (.*)\n')
+regex_url = re.compile(
+        r'^(?:http|ftp)s?://' # http:// or https://
+        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
+        r'localhost|' #localhost...
+        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
+        r'(?::\d+)?' # optional port
+        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+
+skipped_release_files = []
+repos_to_add = []
+for release_file in release_files:
+  with open(PATH + release_file, 'r') as f:
+    read_data = f.read()
+    # parse to get origin and suite
+    origin_string = re.findall(ORIGIN_PATTERN, read_data)
+    suite_string = re.findall(SUITE_PATTERN, read_data)
+    try:
+      repo = "\"%s:%s\";" %(origin_string[0].replace(',',r'\,'),
+                            suite_string[0].replace(',',r'\,'))
+      if re.match(regex_url, origin_string[0]):
+        skipped_release_files.append(release_file)
+      else:
+        repos_to_add.append(repo)
+    except IndexError:
+      skipped_release_files.append(release_file)
+
+## Checking if repos_to_add not already present  in /etc/apt/apt.conf.d/50unattended-upgrades
+with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
+  read_data = f.read()
+  # get everything before first };
+  raw_data = re.findall('[.\s\S]*};', read_data)
+  # replace linux placeholders
+  distro_id, _, distro_codename = platform.linux_distribution()
+  clean_data = raw_data[0].replace("${distro_id}",distro_id).replace("${distro_codename}",distro_codename)
+  repos_already_present = re.findall('".*:.*";', clean_data)
+
+repos_to_add = [repo for repo in repos_to_add if repo not in repos_already_present]
+print ('\n'.join(repos_to_add))


### PR DESCRIPTION
I tried to add a new functionality: I would like to generate a tailor-made /etc/apt/apt.conf.d/50unattended-upgrades file during the installation, so that the user automagically has the repos that he/she were already updating by apt-get by default. This might make it more user-friendly.

