### PR TITLE
Remove double "format" in 50unattended-upgrades files

### DIFF
--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -1,7 +1,7 @@
 // Unattended-Upgrade::Origins-Pattern controls which packages are
 // upgraded.
 //
-// Lines below have the format format is "keyword=value,...".  A
+// Lines below have the format is "keyword=value,...".  A
 // package will be upgraded only if the values in its metadata match
 // all the supplied keywords in a line.  (In other words, omitted
 // keywords are wild cards.) The keywords originate from the Release

--- a/data/50unattended-upgrades.Devuan
+++ b/data/50unattended-upgrades.Devuan
@@ -1,7 +1,7 @@
 // Unattended-Upgrade::Origins-Pattern controls which packages are
 // upgraded.
 //
-// Lines below have the format format is "keyword=value,...".  A
+// Lines below have the format is "keyword=value,...".  A
 // package will be upgraded only if the values in its metadata match
 // all the supplied keywords in a line.  (In other words, omitted
 // keywords are wild cards.) The keywords originate from the Release

--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -1,7 +1,7 @@
 // Unattended-Upgrade::Origins-Pattern controls which packages are
 // upgraded.
 //
-// Lines below have the format format is "keyword=value,...".  A
+// Lines below have the format is "keyword=value,...".  A
 // package will be upgraded only if the values in its metadata match
 // all the supplied keywords in a line.  (In other words, omitted
 // keywords are wild cards.) The keywords originate from the Release


### PR DESCRIPTION
A small grammatical fix in the comments of the default `50unattended-upgrades` files.