### PR TITLE
Adjust only transitive dependencies in the fallback

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -190,13 +190,6 @@ class UnattendedUpgradesCache(apt.Cache):
         except NoAllowedOriginError:
             return False
 
-    def adjust_candidate_for_all_packages(self):
-        """ Adjust origin of all the upgradable/installable packages
-        """
-        for pkg in self:
-            if pkg.is_upgradable or not pkg.is_installed:
-                self.adjust_candidate(pkg)
-
     def call_checked(self, function, pkg, **kwargs):
         """ Call function and check if package is in the wanted state
         """
@@ -232,41 +225,23 @@ class UnattendedUpgradesCache(apt.Cache):
            and not pkg.is_upgradable:
             raise NoAllowedOriginError
         marking_succeeded = self.call_checked(function, pkg, **kwargs)
-        if not marking_succeeded:
-            # The package could not have been marked to install/upgrade
-            # with the current candidate adjustments.
-            # Try marking it without the adjustments then adjust
-            # all packages to be installed/upgraded. This will work where
-            # package dependencies are similar for the adjusted and not
-            # adjusted case, just with different versions.
-            logging.debug("falling back to marking %s without adjustments, "
-                          "then adjusting changes" % pkg.name)
-            for pkg2 in ([self[pkg_name] for pkg_name
-                          in self._cached_candidate_pkgnames]):
-                pkg2.candidate = pkg2.versions[0]
 
-            marking_succeeded = self.call_checked(function, pkg, **kwargs)
-            if marking_succeeded:
-                changes = self.get_changes()
-                for pkg2 in changes:
-                    self.adjust_candidate(pkg2)
-                if all({ver_in_allowed_origin(pkg2, self.allowed_origins)
-                        for pkg2 in changes}):
+        if not marking_succeeded:
+            logging.debug("falling back to adjusting %s's dependencies "
+                          "recursively" % pkg.name)
+            self.clear()
+            # adjust candidates in advance if needed
+            for pkg_name in self._cached_candidate_pkgnames:
+                self.adjust_candidate(self[pkg_name])
+
+            self.adjust_candidate(pkg)
+            for dep in transitive_dependencies(pkg, self):
+                try:
+                    self.adjust_candidate(self[dep])
+                except KeyError:
                     pass
-                else:
-                    # could not adjust all packages in changes to allowed
-                    # candidates
-                    self.clear()
 
-        if not marking_succeeded:
-            # The package could not have been marked to install/upgrade
-            # with the current candidate adjustments.
-            # As a last resort u-u marks _all_ upgradable or
-            # not installed packages' candidates to come from
-            # allowed origins and try marking the package again.
-            logging.debug("falling back to adjusting all packages")
-            self.adjust_candidate_for_all_packages()
-            marking_succeeded = self.call_checked(function, pkg, **kwargs)
+            self.call_checked(function, pkg, **kwargs)
 
         for marked_pkg in self.get_changes():
             if marked_pkg.name in self._cached_candidate_pkgnames:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -857,20 +857,22 @@ def is_pkg_change_allowed(pkg, blacklist, whitelist):
     return True
 
 
-def transitive_dependencies(pkg, cache, acc=set()):
-    # type (apt.Package, apt.Cache, AbstractSet[str]) -> bool
+def transitive_dependencies(pkg, cache, acc=set(), valid_types=None):
+    # type (apt.Package, apt.Cache, AbstractSet[str], AbstractSet[str]) -> bool
     """ All (transitive) dependencies of the package
+
+        Note that alternative (|) dependencies are collected, too
     """
-    # Note that alternative (|) dependencies are collected, too
-    valid_types = {'Depends', 'PreDepends', 'Recommends'}
     for dep in pkg.candidate.dependencies:
         for base_dep in dep:
-            if base_dep.name not in acc and base_dep.rawtype in valid_types:
-                acc.add(base_dep.name)
-                try:
-                    transitive_dependencies(cache[base_dep.name], cache, acc)
-                except KeyError:
-                    pass
+            if base_dep.name not in acc:
+                if not valid_types or base_dep.rawtype in valid_types:
+                    acc.add(base_dep.name)
+                    try:
+                        transitive_dependencies(cache[base_dep.name], cache,
+                                                acc, valid_types)
+                    except KeyError:
+                        pass
     return acc
 
 
@@ -882,10 +884,11 @@ def upgrade_order(to_upgrade, cache):
 
     upgrade_set_sizes = {}
     # calculate upgrade sets
+    follow_deps = {'Depends', 'PreDepends', 'Recommends'}
     for pkgname in to_upgrade:
         pkg = cache[pkgname]
-        upgrade_set_sizes[pkgname] = \
-            len(transitive_dependencies(pkg, cache).intersection(to_upgrade))
+        upgrade_set_sizes[pkgname] = len(transitive_dependencies(
+            pkg, cache, valid_types=follow_deps).intersection(to_upgrade))
     return sorted(upgrade_set_sizes, key=upgrade_set_sizes.get)
 
 


### PR DESCRIPTION
when a package from an allowed origin can't be marked to install/upgrade.

This is a much lighter approach than marking every upgradable package because
the full fallback was triggered on packages held back as well, using an
excessive amount of CPU time.

LP: #1824804