### PR TITLE
Use mark_install_adjusted() in rewind_cache()

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1146,7 +1146,7 @@ def rewind_cache(cache, pkgs_to_upgrade):
     """ set the cache back to the state with packages_to_upgrade """
     cache.clear()
     for pkg2 in pkgs_to_upgrade:
-        pkg2.mark_install(from_user=not pkg2.is_auto_installed)
+        cache.mark_install_adjusted(pkg2, from_user=not pkg2.is_auto_installed)
     if cache.broken_count > 0:
         raise AssertionError("rewind_cache created a broken cache")
 


### PR DESCRIPTION
The original cache had packages marked with adjustments thus rewinding
should also do adjustments to reach the same state.

Also not using mark_install_adjusted() crashes when apt raises error on
held packages.

LP: #1826157