### PR TITLE
Fix showing multi-line strings on Plymouth

### DIFF
--- a/unattended-upgrade-shutdown
+++ b/unattended-upgrade-shutdown
@@ -67,8 +67,9 @@ def do_usplash(msg):
 def do_plymouth(msg):
     # type: (str) -> None
     if os.path.exists("/bin/plymouth"):
-        logging.debug("Running plymouth --text")
-        subprocess.call(["/bin/plymouth", "message", "--text", msg])
+        for l in msg.split("\n"):
+            logging.debug("Running plymouth --text")
+            subprocess.call(["/bin/plymouth", "message", "--text", l])
 
 
 def log_msg(msg, level=logging.WARN):


### PR DESCRIPTION
When unattended-upgrades sends it's status to plymouth it sends a
multi-line string which causes plymouth to display overlapping text,
because plymouth only scrolls one line when the message is sent.

LP: 1826406