### PR TITLE
Use Debian's security updates from $distro-security starting with Bullseye

### DIFF
--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -30,6 +30,7 @@ Unattended-Upgrade::Origins-Pattern {
 //      "origin=Debian,codename=${distro_codename}-proposed-updates";
         "origin=Debian,codename=${distro_codename},label=Debian";
         "origin=Debian,codename=${distro_codename},label=Debian-Security";
+        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
 
         // Archive or Suite based matching:
         // Note that this will silently match a different release after

--- a/debian/tests/common-functions
+++ b/debian/tests/common-functions
@@ -61,7 +61,14 @@ enable_pocket() {
                     pocket_dir="${distro}-proposed-updates"
                     ;;
                 security)
-                    pocket_dir="$distro/updates"
+                    case "$distro" in
+                        stretch|buster)
+                            pocket_dir="$distro/updates"
+                            ;;
+                        *)
+                            pocket_dir="${distro}-$pocket"
+                            ;;
+                    esac
                     mirror_dir_postfix="-security"
                     ;;
                 *)


### PR DESCRIPTION
See: https://lists.debian.org/debian-devel-announce/2019/07/msg00004.html

Gbp-Dch: Short