### PR TITLE
debian/tests/control: Mark upgrade-between-snapshots as flaky

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -7,7 +7,7 @@ Depends: @, @builddeps@, debootstrap, distro-info
 Restrictions: needs-root, build-needed, skippable
 
 Tests: upgrade-between-snapshots
-Restrictions: needs-root, build-needed
+Restrictions: needs-root, build-needed, flaky
 Depends: @, @builddeps@, debootstrap
 
 Tests: kernel-patterns


### PR DESCRIPTION
Closes: #941752