### PR TITLE
debian/unattended-upgrades.service: Add /run to RequiresMountsFor

### DIFF
--- a/debian/unattended-upgrades.service
+++ b/debian/unattended-upgrades.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Unattended Upgrades Shutdown
 After=network.target local-fs.target systemd-logind.service
-RequiresMountsFor=/var/log /var/run /var/lib /boot
+RequiresMountsFor=/run /var/log /var/run /var/lib /boot
 Documentation=man:unattended-upgrade(8)
 
 [Service]


### PR DESCRIPTION
to work around long standing systemd issue of not resolving symlinks to
mounts: https://github.com/systemd/systemd/issues/8907

Closes: #946823