### PR TITLE
Check that a candidate is available before checking the version has changed.

### DIFF
--- a/test/test_unavailable_candidate.py
+++ b/test/test_unavailable_candidate.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from mock import Mock
+
+from unattended_upgrade import calculate_upgradable_pkgs
+
+
+class TestUnavailableCandidate(unittest.TestCase):
+
+    def test_if_pkg_candidate_is_unavailable_then_pkg_is_not_considered(self):
+        origin = Mock()
+        origin.origin = 'allowed-origin'
+
+        pkg = Mock()
+        pkg.name = 'findutils'
+        pkg.is_upgradable = False
+        pkg.is_installed = True
+        pkg.installed = Mock()
+        pkg.installed.policy_priority = -1
+        pkg.installed.origins = [origin]
+        pkg.installed.version = '1:0.1'
+        pkg.candidate = None
+        pkg.versions = [pkg.installed]
+
+        cache = Mock()
+        cache.__iter__ = Mock(return_value=iter([pkg]))
+        options = Mock()
+
+        pkgs_to_upgrade, pkgs_kept_back = \
+            calculate_upgradable_pkgs(
+                cache, options, ['o=allowed-origin'],
+                ['findutils'], [])
+
+        self.assertListEqual([], pkgs_to_upgrade)
+        self.assertEqual(0, len(pkgs_kept_back))
+
+
+if __name__ == "__main__":
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -255,7 +255,7 @@ class UnattendedUpgradesCache(apt.Cache):
                     ver_in_allowed_origin(marked_pkg,
                                           self.allowed_origins)
                     # important! this avoids downgrades below
-                    if pkg.is_installed and not pkg.is_upgradable and\
+                    if pkg.is_installed and not pkg.is_upgradable and \
                             apt_pkg.config.find_b("Unattended-Upgrade::Allow-"
                                                   "downgrade", False):
                         continue
@@ -769,10 +769,7 @@ def upgrade_in_minimal_steps(cache,            # type: UnattendedUpgradesCache
         pkg = cache[pkgname]
         try:
             if pkg.is_upgradable \
-               or (pkg.is_installed
-                   and pkg.candidate.version != pkg.installed.version) \
-                and apt_pkg.config.find_b("Unattended-Upgrade:"
-                                          ":Allow-downgrade", False):
+               or candidate_version_changed(pkg):
                 cache.mark_upgrade_adjusted(
                     pkg, from_user=not pkg.is_auto_installed)
             elif not pkg.is_installed:
@@ -1611,6 +1608,14 @@ def try_to_upgrade(pkg,               # type: apt.Package
         pkgs_kept_back.add(pkg, cache)
 
 
+def candidate_version_changed(pkg,               # type: apt.Package
+                              ):
+    return (pkg.is_installed and pkg.candidate
+            and pkg.candidate.version != pkg.installed.version
+            and apt_pkg.config.find_b(
+                'Unattended-Upgrade::Allow-downgrade', False))
+
+
 def calculate_upgradable_pkgs(cache,             # type: apt.Cache
                               options,           # type: Options
                               allowed_origins,   # type: List[str]
@@ -1624,17 +1629,12 @@ def calculate_upgradable_pkgs(cache,             # type: apt.Cache
     # now do the actual upgrade
     for pkg in cache:
         if options.debug and pkg.is_upgradable \
-           or (pkg.is_installed
-               and pkg.candidate.version != pkg.installed.version) \
-            and apt_pkg.config.find_b(
-                "Unattended-Upgrade::Allow-downgrade", False):
+           or candidate_version_changed(pkg):
             logging.debug("Checking: %s (%s)" % (
                 pkg.name, getattr(pkg.candidate, "origins", [])))
 
-        if (pkg.is_upgradable or ((pkg.is_installed and pkg.candidate.version
-            != pkg.installed.version) and apt_pkg.config.find_b(
-                "Unattended-Upgrade::Allow-downgrade", False))
-                and is_pkgname_in_whitelist(pkg.name, whitelist)):
+        if (pkg.is_upgradable or candidate_version_changed(pkg)
+           and is_pkgname_in_whitelist(pkg.name, whitelist)):
             try:
                 ver_in_allowed_origin(pkg, allowed_origins)
             except NoAllowedOriginError:


### PR DESCRIPTION
# What this change is

This change fixes https://github.com/mvo5/unattended-upgrades/issues/238 where a package installed using dpkg that does not have an upgrade candidate owing to an apt preference, causes calculation of the upgrade to raise an AttributeError. The change involves checking that a candidate exists before checking that the version is different from the installed version.

# Testing done

```shell
sudo ./unattended-upgrade -d --dry-run
```

with a package, alpine-doc, built from alpine source and installed using dpkg, while the following apt preference is set:

```
Package: alpine-doc
Pin: origin www.mirrorservice.org
Pin-Priority: -10
```

The command invocation now succeeds where previously unattended-upgrades crashed with an `AttributeError: 'NoneType' object has no attribute 'version'`.

Also, tests are passing, invoked using

```shell
make -C test
```