### PR TITLE
Update blacklist translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -241,7 +241,7 @@ msgstr "Läuft nicht in der Entwicklungsversion."
 
 #: ../unattended-upgrade:1883
 #, python-format
-msgid "Initial blacklist : %s"
+msgid "Initial blacklist: %s"
 msgstr "Anfangsnegativliste: %s"
 
 #: ../unattended-upgrade:1888

--- a/po/fr.po
+++ b/po/fr.po
@@ -244,7 +244,7 @@ msgstr ""
 
 #: ../unattended-upgrade:1883
 #, fuzzy, python-format
-msgid "Initial blacklist : %s"
+msgid "Initial blacklist: %s"
 msgstr "Paquets initialement sur la liste noire : %s"
 
 #: ../unattended-upgrade:1888

--- a/po/nl.po
+++ b/po/nl.po
@@ -265,7 +265,7 @@ msgstr ""
 
 #: ../unattended-upgrade:1883
 #, python-format
-msgid "Initial blacklist : %s"
+msgid "Initial blacklist: %s"
 msgstr "Initiële zwarte lijst: %s"
 
 #: ../unattended-upgrade:1888

--- a/po/unattended-upgrades.pot
+++ b/po/unattended-upgrades.pot
@@ -222,7 +222,7 @@ msgstr ""
 
 #: ../unattended-upgrade:1883
 #, python-format
-msgid "Initial blacklist : %s"
+msgid "Initial blacklist: %s"
 msgstr ""
 
 #: ../unattended-upgrade:1888

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -514,7 +514,7 @@ def signal_handler(signal, frame):
 
 
 def log_once(msg):
-    #type: (str) -> None
+    # type: (str) -> None
     global logged_msgs
     if msg not in logged_msgs:
         logging.info(msg)
@@ -1996,13 +1996,11 @@ def run(options,             # type: Options
 
     # pkgs that are (for some reason) not safe to install
     blacklist = get_blacklist()
-    logging.info(_("Initial blacklist: %s"),
-                 " ".join(blacklist))
+    logging.info(_("Initial blacklist: %s"), " ".join(blacklist))
 
     # install only these packages regardless of other upgrades available
     whitelist = get_whitelist()
-    logging.info(_("Initial whitelist: %s"),
-                 " ".join(whitelist))
+    logging.info(_("Initial whitelist: %s"), " ".join(whitelist))
 
     logging.info(_("Starting unattended upgrades script"))
 


### PR DESCRIPTION
@mvo5 The space before the colon was removed some time ago, but was not removed from the translation files. Also fixed a pep8 warning in the code.