### PR TITLE
unattended-upgrade-shutdown: fix wait-for-signal

### DIFF
--- a/unattended-upgrade-shutdown
+++ b/unattended-upgrade-shutdown
@@ -339,7 +339,7 @@ class UnattendedUpgradesShutdown():
         res = apt_pkg.get_lock(self.options.lock_file)
         logging.debug("get_lock returned %i" % res)
         # exit here if there is no lock
-        if res > 0:
+        if res < 0:
             logging.debug("lock not taken")
             if self.lock_was_taken:
                 exit_log_result(self.signal_sent)


### PR DESCRIPTION
I've noticed that unattended upgrade on shutdown doesn't work.
After analyzing the code and some test runs, following cought
my attention, from `pydoc3 apt_pkg.get_lock`:

> apt_pkg.get_lock = get_lock(...)
>     get_lock(file: str, errors: bool) -> int
>
>     Create an empty file of the given name and lock it. If the locking
>     succeeds, return the file descriptor of the lock file. Afterwards,
>     locking the file from another process will fail and thus cause
>     get_lock() to return -1 or raise an Error (if 'errors' is True).
>
>     From Python 2.6 on, it is recommended to use the context manager
>     provided by apt_pkg.FileLock instead using the with-statement.

Based on above, I think condition on line 342 should be reversed.
Running `unattended-upgrade-shutdown --wait-for-signal` with my
diff fixes the issue for me.

This addresses mvo5/unattended-upgrades#295