### PR TITLE
Add missing options to config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Supported Options Reference
  packages with the `Unattended-Upgrade::Package-Whitelist-Strict`
  boolean option.
  `Unattended-Upgrade::Package-Blacklist` still applies, thus blacklisted
- packages covered by the whitelist will still not be upraded nor will be
+ packages covered by the whitelist will still not be upgraded nor will be
  installed or upgraded as dependencies of whitelisted packages.
 
  Example:

--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -64,6 +64,24 @@ Unattended-Upgrade::Package-Blacklist {
     // https://docs.python.org/3/howto/regex.html
 };
 
+// Only packages that match the regular expressions in this list will be
+// marked for upgrade. By default dependencies of whitelisted packages
+// are allowed. This can be changed to only ever allow whitelisted
+// packages with the Unattended-Upgrade::Package-Whitelist-Strict
+// boolean option.
+// Unattended-Upgrade::Package-Blacklist still applies, thus blacklisted
+// packages covered by the whitelist will still not be upgraded nor will be
+// installed or upgraded as dependencies of whitelisted packages.
+Unattended-Upgrade::Package-Whitelist {
+//  "bash";
+};
+
+// When set, allow only packages in Unattended-Upgrade::Package-Whitelist
+// to be upgraded. This means that you also need to list all the dependencies
+// of a whitelisted package, e.g. if A depends on B and only A is
+// whitelisted, it will be held back. The default is false.
+//Unattended-Upgrade::Package-Whitelist-Strict "false";
+
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run 
 //   dpkg --force-confold --configure -a
@@ -92,6 +110,12 @@ Unattended-Upgrade::Package-Blacklist {
 // have a working mail setup on your system. A package that provides
 // 'mailx' must be installed. E.g. "user@example.com"
 //Unattended-Upgrade::Mail "";
+
+// Use the specified value in the "From" field of outgoing mails.
+// Default is "root". Be aware that some mail providers do not
+// accept "root" as valid "From" field and therefore will reject
+// the mail.
+//Unattended-Upgrade::Sender "server@example.com";
 
 // Set this value to one of:
 //    "always", "only-on-error" or "on-change"
@@ -123,9 +147,29 @@ Unattended-Upgrade::Package-Blacklist {
 //  Default: "now"
 //Unattended-Upgrade::Automatic-Reboot-Time "02:00";
 
+// Keep the downloaded deb packages after successful installs. By default
+// these are removed after successful installs. Default is false.
+//Unattended-Upgrade::Keep-Debs-After-Install "false"
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Set a dpkg command-line option. This is useful to e.g. force conffile
+// handling in dpkg.
+// Note that unattended-upgrades detects this option, and ensures that
+// packages with configuration prompts will never be held back.
+//
+// Example - force dpkg to keep the old configuration files:
+//Dpkg::Options {"--force-confold"};
+
+// Set the days of the week that updates should be applied. The days
+// can be specified as localized abbreviated or full names. Or as
+// integers where "0" is Sunday, "1" is Monday etc.
+// The default is an empty list which means updates are applied every day.
+//
+// Example - apply updates only on Monday and Friday:
+//Unattended-Upgrade::Update-Days {"Mon";"Fri"};
 
 // Enable logging to syslog. Default is False
 // Unattended-Upgrade::SyslogEnable "false";

--- a/data/50unattended-upgrades.Devuan
+++ b/data/50unattended-upgrades.Devuan
@@ -65,6 +65,24 @@ Unattended-Upgrade::Package-Blacklist {
     // https://docs.python.org/3/howto/regex.html
 };
 
+// Only packages that match the regular expressions in this list will be
+// marked for upgrade. By default dependencies of whitelisted packages
+// are allowed. This can be changed to only ever allow whitelisted
+// packages with the Unattended-Upgrade::Package-Whitelist-Strict
+// boolean option.
+// Unattended-Upgrade::Package-Blacklist still applies, thus blacklisted
+// packages covered by the whitelist will still not be upgraded nor will be
+// installed or upgraded as dependencies of whitelisted packages.
+Unattended-Upgrade::Package-Whitelist {
+//  "bash";
+};
+
+// When set, allow only packages in Unattended-Upgrade::Package-Whitelist
+// to be upgraded. This means that you also need to list all the dependencies
+// of a whitelisted package, e.g. if A depends on B and only A is
+// whitelisted, it will be held back. The default is false.
+//Unattended-Upgrade::Package-Whitelist-Strict "false";
+
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run 
 //   dpkg --force-confold --configure -a
@@ -94,6 +112,12 @@ Unattended-Upgrade::Package-Blacklist {
 // 'mailx' must be installed. E.g. "user@example.com"
 //Unattended-Upgrade::Mail "";
 
+// Use the specified value in the "From" field of outgoing mails.
+// Default is "root". Be aware that some mail providers do not
+// accept "root" as valid "From" field and therefore will reject
+// the mail.
+//Unattended-Upgrade::Sender "server@example.com";
+
 // Set this value to one of:
 //    "always", "only-on-error" or "on-change"
 // If this is not set, then any legacy MailOnlyOnError (boolean) value
@@ -112,7 +136,7 @@ Unattended-Upgrade::Package-Blacklist {
 //Unattended-Upgrade::Remove-Unused-Dependencies "false";
 
 // Automatically reboot *WITHOUT CONFIRMATION* if
-//  the file /var/run/reboot-required is found after the upgrade 
+//  the file /var/run/reboot-required is found after the upgrade
 //Unattended-Upgrade::Automatic-Reboot "false";
 
 // Automatically reboot even if there are users currently logged in
@@ -124,9 +148,29 @@ Unattended-Upgrade::Package-Blacklist {
 //  Default: "now"
 //Unattended-Upgrade::Automatic-Reboot-Time "02:00";
 
+// Keep the downloaded deb packages after successful installs. By default
+// these are removed after successful installs. Default is false.
+//Unattended-Upgrade::Keep-Debs-After-Install "false"
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Set a dpkg command-line option. This is useful to e.g. force conffile
+// handling in dpkg.
+// Note that unattended-upgrades detects this option, and ensures that
+// packages with configuration prompts will never be held back.
+//
+// Example - force dpkg to keep the old configuration files:
+//Dpkg::Options {"--force-confold"};
+
+// Set the days of the week that updates should be applied. The days
+// can be specified as localized abbreviated or full names. Or as
+// integers where "0" is Sunday, "1" is Monday etc.
+// The default is an empty list which means updates are applied every day.
+//
+// Example - apply updates only on Monday and Friday:
+//Unattended-Upgrade::Update-Days {"Mon";"Fri"};
 
 // Enable logging to syslog. Default is False
 // Unattended-Upgrade::SyslogEnable "false";

--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -64,6 +64,24 @@ Unattended-Upgrade::Package-Blacklist {
     // https://docs.python.org/3/howto/regex.html
 };
 
+// Only packages that match the regular expressions in this list will be
+// marked for upgrade. By default dependencies of whitelisted packages
+// are allowed. This can be changed to only ever allow whitelisted
+// packages with the Unattended-Upgrade::Package-Whitelist-Strict
+// boolean option.
+// Unattended-Upgrade::Package-Blacklist still applies, thus blacklisted
+// packages covered by the whitelist will still not be upgraded nor will be
+// installed or upgraded as dependencies of whitelisted packages.
+Unattended-Upgrade::Package-Whitelist {
+//  "bash";
+};
+
+// When set, allow only packages in Unattended-Upgrade::Package-Whitelist
+// to be upgraded. This means that you also need to list all the dependencies
+// of a whitelisted package, e.g. if A depends on B and only A is
+// whitelisted, it will be held back. The default is false.
+//Unattended-Upgrade::Package-Whitelist-Strict "false";
+
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run 
 //   dpkg --force-confold --configure -a
@@ -93,6 +111,12 @@ Unattended-Upgrade::Package-Blacklist {
 // 'mailx' must be installed. E.g. "user@example.com"
 //Unattended-Upgrade::Mail "";
 
+// Use the specified value in the "From" field of outgoing mails.
+// Default is "root". Be aware that some mail providers do not
+// accept "root" as valid "From" field and therefore will reject
+// the mail.
+//Unattended-Upgrade::Sender "server@example.com";
+
 // Set this value to one of:
 //    "always", "only-on-error" or "on-change"
 // If this is not set, then any legacy MailOnlyOnError (boolean) value
@@ -111,7 +135,7 @@ Unattended-Upgrade::Package-Blacklist {
 //Unattended-Upgrade::Remove-Unused-Dependencies "false";
 
 // Automatically reboot *WITHOUT CONFIRMATION* if
-//  the file /var/run/reboot-required is found after the upgrade 
+//  the file /var/run/reboot-required is found after the upgrade
 //Unattended-Upgrade::Automatic-Reboot "false";
 
 // Automatically reboot even if there are users currently logged in
@@ -123,9 +147,29 @@ Unattended-Upgrade::Package-Blacklist {
 //  Default: "now"
 //Unattended-Upgrade::Automatic-Reboot-Time "02:00";
 
+// Keep the downloaded deb packages after successful installs. By default
+// these are removed after successful installs. Default is false.
+//Unattended-Upgrade::Keep-Debs-After-Install "false"
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Set a dpkg command-line option. This is useful to e.g. force conffile
+// handling in dpkg.
+// Note that unattended-upgrades detects this option, and ensures that
+// packages with configuration prompts will never be held back.
+//
+// Example - force dpkg to keep the old configuration files:
+//Dpkg::Options {"--force-confold"};
+
+// Set the days of the week that updates should be applied. The days
+// can be specified as localized abbreviated or full names. Or as
+// integers where "0" is Sunday, "1" is Monday etc.
+// The default is an empty list which means updates are applied every day.
+//
+// Example - apply updates only on Monday and Friday:
+//Unattended-Upgrade::Update-Days {"Mon";"Fri"};
 
 // Enable logging to syslog. Default is False
 // Unattended-Upgrade::SyslogEnable "false";

--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -39,6 +39,24 @@ Unattended-Upgrade::Package-Blacklist {
     // https://docs.python.org/3/howto/regex.html
 };
 
+// Only packages that match the regular expressions in this list will be
+// marked for upgrade. By default dependencies of whitelisted packages
+// are allowed. This can be changed to only ever allow whitelisted
+// packages with the Unattended-Upgrade::Package-Whitelist-Strict
+// boolean option.
+// Unattended-Upgrade::Package-Blacklist still applies, thus blacklisted
+// packages covered by the whitelist will still not be upgraded nor will be
+// installed or upgraded as dependencies of whitelisted packages.
+Unattended-Upgrade::Package-Whitelist {
+//  "bash";
+};
+
+// When set, allow only packages in Unattended-Upgrade::Package-Whitelist
+// to be upgraded. This means that you also need to list all the dependencies
+// of a whitelisted package, e.g. if A depends on B and only A is
+// whitelisted, it will be held back. The default is false.
+//Unattended-Upgrade::Package-Whitelist-Strict "false";
+
 // This option controls whether the development release of Ubuntu will be
 // upgraded automatically. Valid values are "true", "false", and "auto".
 Unattended-Upgrade::DevRelease "auto";
@@ -72,6 +90,12 @@ Unattended-Upgrade::DevRelease "auto";
 // 'mailx' must be installed. E.g. "user@example.com"
 //Unattended-Upgrade::Mail "";
 
+// Use the specified value in the "From" field of outgoing mails.
+// Default is "root". Be aware that some mail providers do not
+// accept "root" as valid "From" field and therefore will reject
+// the mail.
+//Unattended-Upgrade::Sender "server@example.com";
+
 // Set this value to one of:
 //    "always", "only-on-error" or "on-change"
 // If this is not set, then any legacy MailOnlyOnError (boolean) value
@@ -102,9 +126,29 @@ Unattended-Upgrade::DevRelease "auto";
 //  Default: "now"
 //Unattended-Upgrade::Automatic-Reboot-Time "02:00";
 
+// Keep the downloaded deb packages after successful installs. By default
+// these are removed after successful installs. Default is false.
+//Unattended-Upgrade::Keep-Debs-After-Install "false"
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Set a dpkg command-line option. This is useful to e.g. force conffile
+// handling in dpkg.
+// Note that unattended-upgrades detects this option, and ensures that
+// packages with configuration prompts will never be held back.
+//
+// Example - force dpkg to keep the old configuration files:
+//Dpkg::Options {"--force-confold"};
+
+// Set the days of the week that updates should be applied. The days
+// can be specified as localized abbreviated or full names. Or as
+// integers where "0" is Sunday, "1" is Monday etc.
+// The default is an empty list which means updates are applied every day.
+//
+// Example - apply updates only on Monday and Friday:
+//Unattended-Upgrade::Update-Days {"Mon";"Fri"};
 
 // Enable logging to syslog. Default is False
 // Unattended-Upgrade::SyslogEnable "false";


### PR DESCRIPTION
Some options were described in the section "Supported Options Reference" in the README, but were not described in the config files for the different distributions leading to users miss out on these options when they take the default config file as a guide for available options.

Before I had a look at this repository I didn't even know these options existed, because I assumed the config file is "feature-complete". It wasn't, but I think it should be.
It came to my attention, because my mail provider does not consider "root" as a valid "From" field and therefore I never received a mail on upgrades. But of course I did not know that "root" was the default because the option `Unattended-Upgrade::Sender` was missing in my config file (ubuntu).

Btw the option `Unattended-Upgrade::MailReport` was missing on my Ubuntu machine, instead I had the legacy option `Unattended-Upgrade::MailOnlyOnError`, even though `MailReport` is included in the config files in this repository and also handled by the version of `/usr/bin/unattended-upgrade` on my machine (Ubuntu 20.04.3). Is that just `apt` being a bit behind?
