### PR TITLE
github: fix action to use current lts as base for autopkgtest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install autopkgtest git-buildpackage
-        sudo snap install lxd --channel=3.0/stable
+        sudo snap install lxd --channel=stable
         sudo usermod --append --groups lxd $(whoami)
         sudo lxd init  --auto
         sudo autopkgtest-build-lxd ubuntu:$(. /etc/os-release && echo $UBUNTU_CODENAME)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
         sudo snap install lxd --channel=3.0/stable
         sudo usermod --append --groups lxd $(whoami)
         sudo lxd init  --auto
-        sudo autopkgtest-build-lxd ubuntu-daily:groovy
+        sudo autopkgtest-build-lxd ubuntu:$(. /etc/os-release && echo $UBUNTU_CODENAME)
     - name: build source
       run: gbp buildpackage -us -uc -S -d -nc --git-ignore-branch --git-prebuild=
     - name: autopkgtest
       # skipping tests is ok
-      run: sudo autopkgtest -U ../build-area/*.dsc -- lxd autopkgtest/ubuntu/groovy/amd64 || [ $? == 2 ]
+      run: sudo autopkgtest -U ../build-area/*.dsc -- lxd autopkgtest/ubuntu/$(. /etc/os-release && echo $UBUNTU_CODENAME)/amd64 || [ $? == 2 ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,13 @@ jobs:
     - name: setup
       run: |
         sudo apt-get update
-        sudo apt-get install autopkgtest git-buildpackage
+        sudo apt-get install distro-info autopkgtest git-buildpackage
         sudo snap install lxd --channel=stable
         sudo usermod --append --groups lxd $(whoami)
         sudo lxd init  --auto
-        sudo autopkgtest-build-lxd ubuntu:$(. /etc/os-release && echo $UBUNTU_CODENAME)
+        sudo autopkgtest-build-lxd ubuntu:$(distro-info --stable)
     - name: build source
       run: gbp buildpackage -us -uc -S -d -nc --git-ignore-branch --git-prebuild=
     - name: autopkgtest
       # skipping tests is ok
-      run: sudo autopkgtest -U ../build-area/*.dsc -- lxd autopkgtest/ubuntu/$(. /etc/os-release && echo $UBUNTU_CODENAME)/amd64 || [ $? == 2 ]
+      run: sudo autopkgtest -U ../build-area/*.dsc -- lxd autopkgtest/ubuntu/$(distro-info --stable)/amd64 || [ $? == 2 ]


### PR DESCRIPTION
Instead of hardcoding "groovy" this uses the current version of
ubuntu for the lxc image. In addition we could run on latest
ubuntu but I think it's fine for now to only run on the lts.