### PR TITLE
tests: get rid of instruction in Makefile causing syntax error

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -25,5 +25,4 @@ clean:
 	find .. -type d -name __pycache__ | xargs rm -rf
 
 coverage-html:
-	echo "output in htmlcov/
 	python3 -m coverage html


### PR DESCRIPTION
Hello,

Running `make coverage-html` from the `tests/` directory fails because of an `echo` instruction that is missing the closing double-quote.

```
  $ make coverage-html
  echo "output in htmlcov/
  /bin/sh: 1: Syntax error: Unterminated quoted string
  make: *** [Makefile:28: coverage-html] Error 2
```

The echo instruction is supposed to let the user know in which directory they should find the resulting coverage report. Having said that, python3-coverage already writes that information to stdout so it would only make it redundant.

Fixed by removing the echo instruction, which now allows make coverage-html to run:

```
  $ make coverage-html
  python3 -m coverage html
  Wrote HTML report to htmlcov/index.html
```

Thanks