### PR TITLE
test: add `TestBase.mock_distro` and use in tests

### DIFF
--- a/test/test_dev_release.py
+++ b/test/test_dev_release.py
@@ -72,6 +72,7 @@ class TestUntrusted(TestBase):
                                      "apt.conf")
 
         os.rename(self.apt_conf, self.apt_conf + ".bak")
+        self.mock_distro("ubuntu", "artful", "Artful Aardvark (development branch)")
 
     def tearDown(self):
         os.remove(self.log)
@@ -89,7 +90,6 @@ Unattended-Upgrade::OnlyOnAcPower "false";
 
         # run it
         options = MockOptions()
-        unattended_upgrade.DISTRO_DESC = "Artful Aardvark (development branch)"
         unattended_upgrade.main(options, rootdir=self.rootdir)
         # read the log to see what happend
         with open(self.log) as f:
@@ -106,9 +106,6 @@ Unattended-Upgrade::OnlyOnAcPower "false";
         unattended_upgrade.distro_info = MockDistroInfoModule(MockDistroAuto)
 
         options = MockOptions()
-        unattended_upgrade.DISTRO_DESC = "Artful Aardvark (development branch)"
-        unattended_upgrade.DISTRO_CODENAME = "artful"
-        unattended_upgrade.DISTRO_ID = "ubuntu"
         unattended_upgrade.main(options, rootdir=self.rootdir)
         # read the log to see what happend
         with open(self.log) as f:
@@ -125,9 +122,6 @@ Unattended-Upgrade::OnlyOnAcPower "false";
         unattended_upgrade.distro_info = MockDistroInfoModule(MockDistroNoAuto)
 
         options = MockOptions()
-        unattended_upgrade.DISTRO_DESC = "Artful Aardvark (development branch)"
-        unattended_upgrade.DISTRO_CODENAME = "artful"
-        unattended_upgrade.DISTRO_ID = "ubuntu"
         unattended_upgrade.main(options, rootdir=self.rootdir)
         # read the log to see what happend
         with open(self.log) as f:
@@ -145,9 +139,6 @@ Unattended-Upgrade::OnlyOnAcPower "false";
         unattended_upgrade.distro_info = MockDistroInfoModule(MockDistroNoAuto)
 
         options = MockOptions()
-        unattended_upgrade.DISTRO_DESC = "Artful Aardvark (development branch)"
-        unattended_upgrade.DISTRO_CODENAME = "artful"
-        unattended_upgrade.DISTRO_ID = "ubuntu"
         unattended_upgrade.main(options, rootdir=self.rootdir)
         # read the log to see what happend
         with open(self.log) as f:

--- a/test/test_on_battery.py
+++ b/test/test_on_battery.py
@@ -30,6 +30,7 @@ class OnBattery(TestBase):
         self.log = os.path.join(
             self.rootdir, "var", "log", "unattended-upgrades",
             "unattended-upgrades.log")
+        self.mock_distro("ubuntu", "artful", "Artful Aardvark (development branch)")
 
     def tearDown(self):
         os.remove(self.log)
@@ -39,7 +40,6 @@ class OnBattery(TestBase):
 
         # run it
         options = MockOptions()
-        unattended_upgrade.DISTRO_DESC = "Ubuntu 10.04"
         ret = unattended_upgrade.main(options, rootdir=self.rootdir)
         self.assertTrue(ret == 1)
         # read the log to see what happend

--- a/test/test_remove_unused.py
+++ b/test/test_remove_unused.py
@@ -19,9 +19,7 @@ class TestRemoveUnused(TestBase):
     def setUp(self):
         TestBase.setUp(self)
         self.rootdir = os.path.join(self.testdir, "root.unused-deps")
-        unattended_upgrade.DISTRO_ID = "ubuntu"
-        unattended_upgrade.DISTRO_CODENAME = "lucid"
-        unattended_upgrade.DISTRO_DESC = "Ubuntu 10.04"
+        self.mock_distro("ubuntu", "lucid", "ubuntu 10.04")
         # fake on_ac_power
         os.environ["PATH"] = (os.path.join(self.rootdir, "usr", "bin") + ":"
                               + os.environ["PATH"])

--- a/test/test_substitute.py
+++ b/test/test_substitute.py
@@ -7,7 +7,6 @@ import unittest
 import apt_pkg
 apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 
-import unattended_upgrade
 from unattended_upgrade import substitute, get_allowed_origins
 
 from test.test_base import TestBase
@@ -17,9 +16,7 @@ class TestSubstitute(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        # monkey patch DISTRO_{CODENAME, ID}
-        unattended_upgrade.DISTRO_CODENAME = "nacked"
-        unattended_upgrade.DISTRO_ID = "MyDistroID"
+        self.mock_distro("MyDistroID", "mycodename", "MyDistroID descr")
 
     def testSubstitute(self):
         """ test if the substitute function works """
@@ -33,7 +30,7 @@ class TestSubstitute(TestBase):
         apt_pkg.config.set("Unattended-Upgrade::Allowed-Origins::",
                            "${distro_id} ${distro_codename}-security")
         li = get_allowed_origins()
-        self.assertTrue(("o=MyDistroID,a=nacked-security") in li)
+        self.assertIn("o=MyDistroID,a=mycodename-security", li)
 
 
 if __name__ == "__main__":

--- a/test/test_untrusted.py
+++ b/test/test_untrusted.py
@@ -27,6 +27,7 @@ class TestUntrusted(TestBase):
         self.log = os.path.join(
             self.rootdir, "var", "log", "unattended-upgrades",
             "unattended-upgrades.log")
+        self.mock_distro("ubuntu", "lucid", "Ubuntu 10.04")
 
     def tearDown(self):
         os.remove(self.log)
@@ -37,7 +38,6 @@ class TestUntrusted(TestBase):
 
         # run it
         options = MockOptions()
-        unattended_upgrade.DISTRO_DESC = "Ubuntu 10.04"
         unattended_upgrade.main(options, rootdir=self.rootdir)
         # read the log to see what happend
         with open(self.log) as f:


### PR DESCRIPTION
Instead of monkey patching `unattended_upgrade.DISTOR_*` this
commit adds a proper `TestBase.mock_distro()` helper that uses
unittest.mock.patch() and restores the state after the test
again properly.