### PR TITLE
test: add TestBase.make_fake_aptroot() and use in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /build/
 /test/.coverage
 /test/.mypy_cache/
-/test/root.*/
 /test/aptroot/var/cache/
 /test/packages/test-package*.deb
 /test/u-u.lock

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -52,6 +52,8 @@ class TestBase(unittest.TestCase):
             if not k.endswith("::"):
                 self._saved_apt_conf[k] = apt.apt_pkg.config.get(k)
         self.addCleanup(self.enforce_apt_config_reset)
+        # important to ensure that the updated apt config is applied
+        self.addCleanup(apt.apt_pkg.init_system)
 
     def enforce_apt_config_reset(self):
         for k in self._saved_apt_conf:

--- a/test/test_conffile.py
+++ b/test/test_conffile.py
@@ -2,7 +2,6 @@
 
 import os
 import logging
-import shutil
 import unittest
 
 import apt_pkg
@@ -15,30 +14,19 @@ from unattended_upgrade import (
 from test.test_base import TestBase
 
 
-class ConffilePromptTestCase(TestBase):
+class TestConffilePrompt(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        self.rootdir = os.path.join(self.testdir, "root.conffile")
+        self.rootdir = self.make_fake_aptroot(
+            template=os.path.join(self.testdir, "root.conffile"))
         self.packagedir = os.path.join(self.testdir, "packages")
-        mock_dpkg_status = os.path.join(self.rootdir, "var/lib/dpkg/status")
-        apt_pkg.config.set("Dir::State::status", mock_dpkg_status)
         with open(os.path.join(
                 self.rootdir, "etc/configuration-file"), "w") as fp:
             fp.write("""This is a configuration file,
 dfasddfasdff
 No really.
 """)
-
-    def tearDown(self):
-        try:
-            os.remove(os.path.join(self.rootdir, "etc/configuration-file"))
-        except Exception:
-            pass
-        try:
-            shutil.rmtree(os.path.join(self.rootdir, "etc/configuration-file"))
-        except Exception:
-            pass
 
     def test_will_prompt(self):
         # conf-test 0.9 is installed, 1.1 gets installed
@@ -60,7 +48,7 @@ No really.
     def test_prompt_on_deleted_modified_conffile(self):
         # conf-test 0.9 is installed, 1.1 gets installed
         # they both have different config files, this triggers a prompt
-        os.remove("./root.conffile/etc/configuration-file")
+        os.remove(os.path.join(self.rootdir, "etc/configuration-file"))
         test_pkg = os.path.join(self.packagedir, "conf-test-package_1.1.deb")
         self.assertTrue(conffile_prompt(test_pkg, prefix=self.rootdir),
                         "conffile prompt detection incorrect")

--- a/test/test_dev_release.py
+++ b/test/test_dev_release.py
@@ -61,22 +61,14 @@ class TestDevRelease(TestBase):
                                "false")
         apt.apt_pkg.config.set("Unattended-Upgrade::OnlyOnAcPower",
                                "false")
-        self.rootdir = os.path.join(self.testdir, "root.untrusted")
-        apt.apt_pkg.config.set("Dir::State::status", os.path.join(
-            self.rootdir, "var/lib/dpkg/status"))
+        self.rootdir = self.make_fake_aptroot(
+            template=os.path.join(self.testdir, "root.untrusted"))
         self.log = os.path.join(
             self.rootdir, "var", "log", "unattended-upgrades",
             "unattended-upgrades.log")
-
         self.apt_conf = os.path.join(self.rootdir, "etc", "apt",
                                      "apt.conf")
-
-        os.rename(self.apt_conf, self.apt_conf + ".bak")
         self.mock_distro("ubuntu", "artful", "Artful Aardvark (development branch)")
-
-    def tearDown(self):
-        os.remove(self.log)
-        os.rename(self.apt_conf + ".bak", self.apt_conf)
 
     def write_config(self, devrelease):
         with open(self.apt_conf, "w") as fp:

--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -17,21 +17,14 @@ class TestRewindCache(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        rootdir = os.path.join(self.testdir, "root.rewind")
-        dpkg_status = os.path.abspath(
-            os.path.join(rootdir, "var", "lib", "dpkg", "status"))
-        apt.apt_pkg.config.set("Dir::State::status", dpkg_status)
-        apt.apt_pkg.config.set(
-            "Unattended-Upgrade::Allow-APT-Mark-Fallback", "true")
-        self.cache = unattended_upgrade.UnattendedUpgradesCache(
-            rootdir=rootdir)
+        rootdir = self.make_fake_aptroot(os.path.join(self.testdir, "root.rewind"))
+        self.cache = unattended_upgrade.UnattendedUpgradesCache(rootdir=rootdir)
 
     def test_rewind_cache(self):
         """ Test that rewinding the cache works correctly, debian #743594 """
         options = MockOptions()
         options.try_run = True
-        to_upgrade = unattended_upgrade.calculate_upgradable_pkgs(
-            self.cache, options)
+        to_upgrade = unattended_upgrade.calculate_upgradable_pkgs(self.cache, options)
         self.assertEqual(to_upgrade, [self.cache[p] for p
                                       in ["test-package", "test2-package",
                                           "test3-package"]])

--- a/test/test_untrusted.py
+++ b/test/test_untrusted.py
@@ -18,25 +18,14 @@ class TestUntrusted(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        self.rootdir = os.path.join(self.testdir, "root.untrusted")
-        dpkg_status = os.path.abspath(
-            os.path.join(self.rootdir, "var", "lib", "dpkg", "status"))
-        apt.apt_pkg.config.set("Dir::State::status", dpkg_status)
-        apt.apt_pkg.config.clear("DPkg::Pre-Invoke")
-        apt.apt_pkg.config.clear("DPkg::Post-Invoke")
+        self.rootdir = self.make_fake_aptroot(
+            template=os.path.join(self.testdir, "root.untrusted"))
         self.log = os.path.join(
             self.rootdir, "var", "log", "unattended-upgrades",
             "unattended-upgrades.log")
         self.mock_distro("ubuntu", "lucid", "Ubuntu 10.04")
 
-    def tearDown(self):
-        os.remove(self.log)
-
     def test_untrusted_check_without_conffile_check(self):
-        # ensure there is no conffile_prompt check
-        apt.apt_pkg.config.set("DPkg::Options::", "--force-confold")
-
-        # run it
         options = MockOptions()
         unattended_upgrade.main(options, rootdir=self.rootdir)
         # read the log to see what happend


### PR DESCRIPTION
The new `TestBase.make_fake_aptroot()` will create a fake aptroot
based on an exiting template. It will also create a fake dpkg
inside it that just writes what arguments got passed to it.

This ensures that the local git tree is not polluted with generated
files during the test runs.

Use the new helper in the tests that use a fake root directory.