### PR TITLE
test: remove global `apt_pkg.config.set()` settings in tests

### DIFF
--- a/test/test_against_real_archive.py
+++ b/test/test_against_real_archive.py
@@ -12,8 +12,6 @@ import re
 import unittest
 
 import apt_pkg
-
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 import apt
 
 import unattended_upgrade

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -46,6 +46,11 @@ class TestBase(unittest.TestCase):
         unattended_upgrade.LOCK_FILE = os.path.join(self.tempdir, "u-u.lock")
         # reset apt config
         apt.apt_pkg.init_config()
+        apt.apt_pkg.config.set("APT::Architecture", "amd64")
+        # FIXME: would be nice to only set this if needed
+        apt.apt_pkg.config.set(
+            "Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
+        apt.apt_pkg.init_system()
         # must be last
         self._saved_apt_conf = {}
         for k in apt.apt_pkg.config.keys():

--- a/test/test_clean.py
+++ b/test/test_clean.py
@@ -5,8 +5,6 @@ import os
 import os.path
 import unittest
 
-import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 import apt
 import unattended_upgrade
 

--- a/test/test_conffile.py
+++ b/test/test_conffile.py
@@ -5,7 +5,6 @@ import logging
 import unittest
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 
 from unattended_upgrade import (
     conffile_prompt,

--- a/test/test_dev_release.py
+++ b/test/test_dev_release.py
@@ -9,8 +9,6 @@ import apt
 from test.test_base import TestBase, MockOptions
 import unattended_upgrade
 
-apt.apt_pkg.config.set("APT::Architecture", "amd64")
-
 
 class MockDistroAuto(object):
 

--- a/test/test_in_chroot.py
+++ b/test/test_in_chroot.py
@@ -9,9 +9,6 @@ import subprocess
 import time
 import unittest
 
-import apt_pkg
-
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 import apt
 
 # debian

--- a/test/test_log_install_progress.py
+++ b/test/test_log_install_progress.py
@@ -6,7 +6,6 @@ import os.path
 import unittest
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 
 from test.test_base import TestBase, MockOptions
 

--- a/test/test_logdir.py
+++ b/test/test_logdir.py
@@ -5,7 +5,7 @@ import os
 import unittest
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
+
 
 from unattended_upgrade import _setup_logging
 from test.test_base import TestBase, MockOptions

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -12,7 +12,6 @@ import unittest
 
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 
 import unattended_upgrade
 from unattended_upgrade import (

--- a/test/test_minimal_partitions.py
+++ b/test/test_minimal_partitions.py
@@ -4,7 +4,7 @@ import os
 import unittest
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
+
 import apt
 
 try:

--- a/test/test_on_battery.py
+++ b/test/test_on_battery.py
@@ -3,15 +3,9 @@
 import os
 import unittest
 
-import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
-import apt
-
 from test.test_base import MockOptions, TestBase
 
 import unattended_upgrade
-
-apt.apt_pkg.config.set("APT::Architecture", "amd64")
 
 
 class TestOnBattery(TestBase):

--- a/test/test_origin_pattern.py
+++ b/test/test_origin_pattern.py
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 
 import logging
-import os
 import unittest
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 
 import unattended_upgrade
 from unattended_upgrade import (

--- a/test/test_reboot.py
+++ b/test/test_reboot.py
@@ -7,11 +7,10 @@ import unittest
 import subprocess
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 
-from mock import (
-    patch,
-)
+
+from mock import patch
+
 
 import unattended_upgrade
 from test.test_base import TestBase

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -8,7 +8,6 @@ import tempfile
 import unittest
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 
 from mock import (
     Mock,

--- a/test/test_remove_unused.py
+++ b/test/test_remove_unused.py
@@ -4,8 +4,6 @@ import os
 import subprocess
 import unittest
 
-import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 import apt
 
 from test.test_base import TestBase, MockOptions

--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -3,8 +3,6 @@
 import os
 import unittest
 
-import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
 import apt
 
 import unattended_upgrade

--- a/test/test_substitute.py
+++ b/test/test_substitute.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 
 import logging
-import os
 import unittest
 
 import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
+
 
 from unattended_upgrade import substitute, get_allowed_origins
 

--- a/test/test_untrusted.py
+++ b/test/test_untrusted.py
@@ -3,15 +3,9 @@
 import os
 import unittest
 
-import apt_pkg
-apt_pkg.config.set("Dir", os.path.join(os.path.dirname(__file__), "aptroot"))
-import apt
-
 from test.test_base import TestBase, MockOptions
 
 import unattended_upgrade
-
-apt.apt_pkg.config.set("APT::Architecture", "amd64")
 
 
 class TestUntrusted(TestBase):


### PR DESCRIPTION
The existing tests did a lot of global `apt_pkg.config.set()` calls
that are confusing. Instead consolidate all of those inside
`TestBase.setUp()`.