### PR TITLE
Catch PermissionError when executing on_ac_power

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -703,7 +703,7 @@ def should_stop():
            and subprocess.call("on_ac_power") == 1:
             logging.warning("System is on battery power, stopping")
             return True
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         log_once(
             _("Checking if system is running on battery is skipped. Please "
               "install powermgmt-base package to check power status and skip "


### PR DESCRIPTION
Reproducible with:

$ touch /usr/bin/on_ac_power

and powermgmt-base not installed.

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1031880