### PR TITLE
Consider conffile prompts to be errors when there's nothing else to do

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -2371,7 +2371,7 @@ def run(options,             # type: Options
 
         pkgs_kept_back = cache.find_kept_packages(options.dry_run)
         return UnattendedUpgradesResult(
-            kernel_pkgs_remove_success,
+            kernel_pkgs_remove_success and not pkg_conffile_prompt,
             _("No packages found that can be upgraded unattended and no "
               "pending auto-removals"),
             pkgs_removed=kernel_pkgs_removed,


### PR DESCRIPTION
Unless there are also packages that can be upgraded, processing won't get beyond "exit if there is nothing to do" to report a failure result because of conffile prompts.

Check for conffile prompts when determining success/failure at the earlier "nothing to do" stage.

Fixes #336.