### PR TITLE
python2 cleaup

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Build-Depends-Indep: python3-dev,
 #                    powermgmt-base, (tests disable on_ac_power checks)
                      flake8,
                      python3-apt (>= 1.9.6~),
-                     python3-mock,
                      lsb-release
 Standards-Version: 4.1.4
 Vcs-Git: https://github.com/mvo5/unattended-upgrades.git

--- a/test/test_blacklisted_wrong_origin.py
+++ b/test/test_blacklisted_wrong_origin.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
-import sys
 import unittest
-
-from mock import (
+from unittest.mock import (
     Mock,
 )
+
 from test.test_base import TestBase
 
 from unattended_upgrade import calculate_upgradable_pkgs
@@ -14,7 +13,6 @@ from unattended_upgrade import calculate_upgradable_pkgs
 
 class TestBlacklistedWrongOrigin(TestBase):
 
-    @unittest.skipIf(sys.version_info[0] != 3, "only works on py3")
     def test_if_origin_does_not_match_then_blacklist_is_not_checked(self):
         origin = Mock()
         origin.origin = "some-other-origin"

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -1,12 +1,9 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from email.parser import Parser
 from io import StringIO
-from mock import patch
+from unittest.mock import patch
 import os
-import sys
 from textwrap import dedent
 import unittest
 
@@ -272,10 +269,6 @@ class SendmailTestCase(CommonTestsForMailxAndSendmail, TestBase):
     def _verify_common_mail_content(self, mail_txt):
         CommonTestsForMailxAndSendmail._verify_common_mail_content(
             self, mail_txt)
-
-        # python2 needs this as utf8 encoded string (not unicode)
-        if sys.version < '3':
-            mail_txt = mail_txt.encode("utf-8")
 
         msg = Parser().parsestr(mail_txt)
         content_type = msg["Content-Type"]

--- a/test/test_patch_days.py
+++ b/test/test_patch_days.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 import apt
 

--- a/test/test_reboot.py
+++ b/test/test_reboot.py
@@ -5,11 +5,10 @@ import logging
 import os
 import unittest
 import subprocess
+from unittest.mock import patch
 
 import apt_pkg
 
-
-from mock import patch
 
 
 import unattended_upgrade

--- a/test/test_reboot.py
+++ b/test/test_reboot.py
@@ -9,8 +9,6 @@ from unittest.mock import patch
 
 import apt_pkg
 
-
-
 import unattended_upgrade
 from test.test_base import TestBase
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -3,16 +3,14 @@
 
 import io
 import os
-import sys
 import tempfile
 import unittest
-
-import apt_pkg
-
-from mock import (
+from unittest.mock import (
     Mock,
     patch,
 )
+
+import apt_pkg
 
 from unattended_upgrade import do_install
 from test.test_base import TestBase
@@ -37,7 +35,6 @@ class MockCache(dict):
 
 class TestRegression(TestBase):
 
-    @unittest.skipIf(sys.version_info[0] != 3, "only works on py3")
     @patch("unattended_upgrade.upgrade_normal")
     def test_do_install_fail_unicode_write(self, mock_upgrade_normal):
         """ test if the substitute function works """

--- a/test/test_unavailable_candidate.py
+++ b/test/test_unavailable_candidate.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-
-from mock import Mock
+from unittest.mock import Mock
 
 from unattended_upgrade import calculate_upgradable_pkgs
 from test.test_base import TestBase


### PR DESCRIPTION
cleanup of remaing Python2 compatibility code.

unittest.mock is already used is some other places.

https://github.com/testing-cabal/mock

> mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.