### PR TITLE
Correct examples for Debian backports

### DIFF
--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -31,6 +31,7 @@ Unattended-Upgrade::Origins-Pattern {
         "origin=Debian,codename=${distro_codename},label=Debian";
         "origin=Debian,codename=${distro_codename},label=Debian-Security";
         "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
+//      "o=Debian Backports,n=${distro_codename}-backports,l=Debian Backports";
 
         // Archive or Suite based matching:
         // Note that this will silently match a different release after
@@ -39,7 +40,7 @@ Unattended-Upgrade::Origins-Pattern {
 //      "o=Debian,a=stable";
 //      "o=Debian,a=stable-updates";
 //      "o=Debian,a=proposed-updates";
-//      "o=Debian Backports,a=${distro_codename}-backports,l=Debian Backports";
+//      "o=Debian Backports,a=stable-backports,l=Debian Backports";
 };
 
 // Python regular expressions, matching packages to exclude from upgrading


### PR DESCRIPTION
The examples list a=${distro_codename}-backports as valid, while this should be n=${distro_codename}-backports or
codename=${distro_codename}-backports or a=stable-backports

Closes: #940151