### PR TITLE
Simplify logrotate config for unattended-upgrades logs

### DIFF
--- a/data/logrotate.d/unattended-upgrades
+++ b/data/logrotate.d/unattended-upgrades
@@ -1,6 +1,4 @@
-/var/log/unattended-upgrades/unattended-upgrades.log 
-/var/log/unattended-upgrades/unattended-upgrades-dpkg.log
-/var/log/unattended-upgrades/unattended-upgrades-shutdown.log
+/var/log/unattended-upgrades/*.log
 {
   rotate 6
   monthly


### PR DESCRIPTION
To reduce redundancy and improve maintainability of the log rotation configuration, we can simplify the individual log entries by matching all `.log` files with a wildcard.