### PR TITLE
Install systemd-sleep part into /usr/lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
                 ["pm/sleep.d/10_unattended-upgrades-hibernate"]),
             ('../etc/kernel/postinst.d/',
                 glob.glob("kernel/postinst.d/*")),
-            ('../lib/systemd/system-sleep/',
+            ('../usr/lib/systemd/system-sleep/',
                 ["debian/systemd-sleep/unattended-upgrades"]),
             ('../usr/share/apport/package-hooks/',
                 ["debian/source_unattended-upgrades.py"])


### PR DESCRIPTION
Closes: #1073745

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1073745
