### PR TITLE
u-u: import "email.genators" package early as workaround

### DIFF
--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -28,6 +28,9 @@ import copy
 import datetime
 import errno
 import email.charset
+# workaround LP:2080940, email.errors changes as part of a security
+# update in python itself but is lazy loaded so import early to ensure
+import email.generator
 import fcntl
 import fnmatch
 import gettext


### PR DESCRIPTION
This commit works around an issue when python itself is upgraded
by u-u and the content of email.message now needs a newer email.errors
but u-u already (implicitely) loaded that module so there is a
old version in sys.modules. So instead import email.generators early
so that it is available in memory and there is no mismatch.

See https://github.com/python/cpython/issues/124170 and
https://bugs.launchpad.net/ubuntu/+source/python3.8/+bug/2080940
for details.

Unfortunately while this commit fixes the autopkgtest failure that
is now triggered by this the real issue that the users see is not
fixed because the "old" unattended-upgrades will perform the upgrade
and it will upgrade both the problematic python and the fixed u-u
but because u-u does not re-exec the "old" u-u still runs and the
fixed code from u-u will not be used.

Thanks to Julian Klode for his excellent analysis.
