### PR TITLE
both usage of pycodestyle & pep8 has been removed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,6 @@ Build-Depends-Indep: python3-dev,
                      python3-coverage,
                      python3-distro-info,
                      python3-pytest,
-                     pycodestyle | pep8,
 #                    powermgmt-base, (tests disable on_ac_power checks)
                      flake8,
                      python3-apt (>= 1.9.6~),


### PR DESCRIPTION
I'm trying to remove old `pep8` from Debian.
