### PR TITLE
Document prefix example for Package-Blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,14 @@ Supported Options Reference
  that it's a list of regular expressions, so you may need to escape special
  characters like "+" as "\\+".
  
- Example:
+ Example: Any package with the "vim" prefix, including `vim` and `vim-doc`.
+ ```
+ Unattended-Upgrade::Package-Blacklist {
+     "vim";
+ };
+ ```
+ 
+ Example: Only the exact `libstdc++6` package.
  ```
  Unattended-Upgrade::Package-Blacklist {
      "libstdc\+\+6$";


### PR DESCRIPTION
* Explain meaning of existing example.
* Add example that uses a simple prefix.

I'm using this on Debian Trixie. As someone new to this, it took me a while to figure out whether something like `*` (glob/fnmatch style) or `.*` was required. The Debian docs point to this repo.

Ultimately, through the [Ubuntu guide](https://documentation.ubuntu.com/server/how-to/software/automatic-updates/), I figured it should work fine without that. I suggest adding this here to confirm that this is indeed blessed/supported usage, and so that others may find it more easily in the future.