### PR TITLE
MinimumAge option with state tracking and fallback policy

### DIFF
--- a/data/50unattended-upgrades.Debian
+++ b/data/50unattended-upgrades.Debian
@@ -77,6 +77,18 @@ Unattended-Upgrade::Package-Blacklist {
 // is running is possible (with a small delay)
 //Unattended-Upgrade::MinimalSteps "true";
 
+// Delay package upgrades until each package version has been available
+// for at least N days/hours.
+// Examples: "7" (7 days), "7d" (7 days), "12h" (12 hours).
+// If no suffix is specified, days are assumed.
+//Unattended-Upgrade::MinimumAge "7";
+
+// What to do when the age of a package cannot be determined
+// (corrupted state file, unwritable filesystem, clock skew, etc.)
+// "hold" = keep package back (conservative, default)
+// "install" = install anyway (prioritize security updates over delay policy)
+//Unattended-Upgrade::MinimumAge-Fallback "hold";
+
 // Install all updates when the machine is shutting down
 // instead of doing it in the background while the machine is running.
 // This will (obviously) make shutdown slower.

--- a/data/50unattended-upgrades.Devuan
+++ b/data/50unattended-upgrades.Devuan
@@ -77,6 +77,18 @@ Unattended-Upgrade::Package-Blacklist {
 // is running is possible (with a small delay)
 //Unattended-Upgrade::MinimalSteps "true";
 
+// Delay package upgrades until each package version has been available
+// for at least N days/hours.
+// Examples: "7" (7 days), "7d" (7 days), "12h" (12 hours).
+// If no suffix is specified, days are assumed.
+//Unattended-Upgrade::MinimumAge "7";
+
+// What to do when the age of a package cannot be determined
+// (corrupted state file, unwritable filesystem, clock skew, etc.)
+// "hold" = keep package back (conservative, default)
+// "install" = install anyway (prioritize security updates over delay policy)
+//Unattended-Upgrade::MinimumAge-Fallback "hold";
+
 // Install all updates when the machine is shutting down
 // instead of doing it in the background while the machine is running.
 // This will (obviously) make shutdown slower.

--- a/data/50unattended-upgrades.Raspbian
+++ b/data/50unattended-upgrades.Raspbian
@@ -76,6 +76,18 @@ Unattended-Upgrade::Package-Blacklist {
 // is running is possible (with a small delay)
 //Unattended-Upgrade::MinimalSteps "true";
 
+// Delay package upgrades until each package version has been available
+// for at least N days/hours.
+// Examples: "7" (7 days), "7d" (7 days), "12h" (12 hours).
+// If no suffix is specified, days are assumed.
+//Unattended-Upgrade::MinimumAge "7";
+
+// What to do when the age of a package cannot be determined
+// (corrupted state file, unwritable filesystem, clock skew, etc.)
+// "hold" = keep package back (conservative, default)
+// "install" = install anyway (prioritize security updates over delay policy)
+//Unattended-Upgrade::MinimumAge-Fallback "hold";
+
 // Install all updates when the machine is shutting down
 // instead of doing it in the background while the machine is running.
 // This will (obviously) make shutdown slower.

--- a/data/50unattended-upgrades.Ubuntu
+++ b/data/50unattended-upgrades.Ubuntu
@@ -55,6 +55,18 @@ Unattended-Upgrade::DevRelease "auto";
 // is running is possible (with a small delay)
 //Unattended-Upgrade::MinimalSteps "true";
 
+// Delay package upgrades until each package version has been available
+// for at least N days/hours.
+// Examples: "7" (7 days), "7d" (7 days), "12h" (12 hours).
+// If no suffix is specified, days are assumed.
+//Unattended-Upgrade::MinimumAge "7";
+
+// What to do when the age of a package cannot be determined
+// (corrupted state file, unwritable filesystem, clock skew, etc.)
+// "hold" = keep package back (conservative, default)
+// "install" = install anyway (prioritize security updates over delay policy)
+//Unattended-Upgrade::MinimumAge-Fallback "hold";
+
 // Install all updates when the machine is shutting down
 // instead of doing it in the background while the machine is running.
 // This will (obviously) make shutdown slower.

--- a/test/test_minimum_age.py
+++ b/test/test_minimum_age.py
@@ -1,0 +1,470 @@
+#!/usr/bin/python3
+
+import datetime
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from unittest.mock import Mock, patch
+
+import apt_pkg
+
+import unattended_upgrade
+from unattended_upgrade import (
+    calculate_upgradable_pkgs,
+    first_seen_age_days,
+    first_seen_age_delta,
+    load_seen_versions,
+    minimum_age_reason_for_version,
+    parse_minimum_age_setting,
+    record_seen_versions,
+    MINIMUM_AGE_FALLBACK_HOLD,
+    MINIMUM_AGE_FALLBACK_INSTALL,
+    save_seen_versions,
+    SEEN_VERSIONS_FILE,
+)
+
+from test.test_base import TestBase, MockOptions
+
+
+class TestParseMinimumAgeSetting(unittest.TestCase):
+
+    def test_plain_integer_means_days(self):
+        delta, label = parse_minimum_age_setting("7")
+        self.assertEqual(delta, datetime.timedelta(days=7))
+        self.assertEqual(label, "7d")
+
+    def test_days_suffix(self):
+        delta, label = parse_minimum_age_setting("2d")
+        self.assertEqual(delta, datetime.timedelta(days=2))
+        self.assertEqual(label, "2d")
+
+    def test_hours_suffix(self):
+        delta, label = parse_minimum_age_setting("12h")
+        self.assertEqual(delta, datetime.timedelta(hours=12))
+        self.assertEqual(label, "12h")
+
+    def test_invalid_value_disables_minimum_age(self):
+        delta, label = parse_minimum_age_setting("abc")
+        self.assertEqual(delta, datetime.timedelta(0))
+        self.assertEqual(label, "0d")
+
+
+class TestLoadSeenVersions(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir)
+
+    def test_load_missing_file(self):
+        path = os.path.join(self.tmpdir, "nonexistent.json")
+        result = load_seen_versions(path)
+        self.assertEqual(result, {})
+
+    def test_load_valid_file(self):
+        path = os.path.join(self.tmpdir, "seen.json")
+        data = {
+            "_format_version": 1,
+            "packages": {
+                "bash": {"5.2-3": "2026-02-08T01:02:03Z"},
+                "openssl": {"3.0.13-1": "2026-02-01T04:05:06Z"},
+            },
+        }
+        with open(path, "w") as fp:
+            json.dump(data, fp)
+        result = load_seen_versions(path)
+        self.assertEqual(result, data["packages"])
+
+    def test_load_corrupt_json(self):
+        path = os.path.join(self.tmpdir, "corrupt.json")
+        with open(path, "w") as fp:
+            fp.write("{not valid json!!")
+        result = load_seen_versions(path)
+        self.assertEqual(result, {})
+
+    def test_load_wrong_format_version(self):
+        path = os.path.join(self.tmpdir, "wrong.json")
+        data = {
+            "_format_version": 99,
+            "packages": {"bash": {"1.0": "2026-01-01T00:00:00Z"}},
+        }
+        with open(path, "w") as fp:
+            json.dump(data, fp)
+        result = load_seen_versions(path)
+        self.assertEqual(result, {})
+
+
+class TestSaveSeenVersions(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir)
+
+    def test_save_creates_file(self):
+        path = os.path.join(self.tmpdir, "subdir", "seen.json")
+        packages = {"bash": {"5.2-3": "2026-02-08T01:02:03Z"}}
+        save_seen_versions(path, packages)
+        self.assertTrue(os.path.exists(path))
+        with open(path, "r") as fp:
+            data = json.load(fp)
+        self.assertEqual(data["_format_version"], 1)
+        self.assertEqual(data["packages"], packages)
+
+    def test_save_roundtrip(self):
+        path = os.path.join(self.tmpdir, "seen.json")
+        packages = {
+            "bash": {"5.2-3": "2026-02-08T01:02:03Z"},
+            "openssl": {"3.0.13-1": "2026-02-01T04:05:06Z"},
+        }
+        save_seen_versions(path, packages)
+        loaded = load_seen_versions(path)
+        self.assertEqual(loaded, packages)
+
+
+class TestFirstSeenAge(unittest.TestCase):
+
+    def test_first_seen_age_delta_hours(self):
+        now = datetime.datetime(2026, 2, 15, 12, 0, 0)
+        seen = {"bash": {"5.2-3": "2026-02-15T00:00:00Z"}}
+        age = first_seen_age_delta("bash", "5.2-3", seen, now=now)
+        self.assertEqual(age, datetime.timedelta(hours=12))
+
+    def test_first_seen_age_days_compat(self):
+        today = datetime.date(2026, 2, 15)
+        seen = {"bash": {"5.2-3": "2026-02-08T00:00:00Z"}}
+        age = first_seen_age_days("bash", "5.2-3", seen, today=today)
+        self.assertEqual(age, 7)
+
+    def test_first_seen_unknown_package(self):
+        seen = {"bash": {"5.2-3": "2026-02-08T00:00:00Z"}}
+        age = first_seen_age_delta("curl", "7.88.1-10", seen)
+        self.assertIsNone(age)
+
+    def test_first_seen_unknown_version(self):
+        seen = {"bash": {"5.2-3": "2026-02-08T00:00:00Z"}}
+        age = first_seen_age_delta("bash", "5.2-4", seen)
+        self.assertIsNone(age)
+
+    def test_first_seen_clock_skew_negative(self):
+        now = datetime.datetime(2026, 2, 10, 0, 0, 0)
+        seen = {"bash": {"5.2-3": "2026-02-15T00:00:00Z"}}
+        age = first_seen_age_delta("bash", "5.2-3", seen, now=now)
+        self.assertEqual(age, datetime.timedelta(0))
+
+    def test_first_seen_invalid_timestamp(self):
+        seen = {"bash": {"5.2-3": "2026-02-08"}}
+        age = first_seen_age_delta("bash", "5.2-3", seen)
+        self.assertIsNone(age)
+
+
+class TestMinimumAgeReasonForVersion(unittest.TestCase):
+
+    def test_minimum_age_disabled(self):
+        result = minimum_age_reason_for_version(
+            "bash", "5.2-3", datetime.timedelta(0), {},
+            MINIMUM_AGE_FALLBACK_HOLD)
+        self.assertIsNone(result)
+
+    def test_minimum_age_too_young_days(self):
+        now = datetime.datetime(2099, 1, 15, 0, 0, 0)
+        seen = {"bash": {"5.2-3": "2099-01-13T00:00:00Z"}}
+        result = minimum_age_reason_for_version(
+            "bash", "5.2-3", datetime.timedelta(days=7), seen,
+            MINIMUM_AGE_FALLBACK_HOLD, now=now, minimum_age_label="7d")
+        self.assertIsNotNone(result)
+        self.assertIn("keeping back", result)
+        self.assertIn("MinimumAge: 7d", result)
+
+    def test_minimum_age_old_enough_days(self):
+        now = datetime.datetime(2099, 1, 15, 0, 0, 0)
+        seen = {"bash": {"5.2-3": "2099-01-05T00:00:00Z"}}
+        result = minimum_age_reason_for_version(
+            "bash", "5.2-3", datetime.timedelta(days=7), seen,
+            MINIMUM_AGE_FALLBACK_HOLD, now=now, minimum_age_label="7d")
+        self.assertIsNone(result)
+
+    def test_minimum_age_too_young_hours(self):
+        now = datetime.datetime(2099, 1, 15, 12, 0, 0)
+        seen = {"bash": {"5.2-3": "2099-01-15T00:00:00Z"}}
+        result = minimum_age_reason_for_version(
+            "bash", "5.2-3", datetime.timedelta(hours=24), seen,
+            MINIMUM_AGE_FALLBACK_HOLD, now=now, minimum_age_label="24h")
+        self.assertIsNotNone(result)
+        self.assertIn("MinimumAge: 24h", result)
+
+    def test_minimum_age_exactly_enough_hours(self):
+        now = datetime.datetime(2099, 1, 16, 0, 0, 0)
+        seen = {"bash": {"5.2-3": "2099-01-15T00:00:00Z"}}
+        result = minimum_age_reason_for_version(
+            "bash", "5.2-3", datetime.timedelta(hours=24), seen,
+            MINIMUM_AGE_FALLBACK_HOLD, now=now, minimum_age_label="24h")
+        self.assertIsNone(result)
+
+
+class TestFallbackPolicy(unittest.TestCase):
+
+    NOW = datetime.datetime(2099, 1, 15, 0, 0, 0)
+    MIN_AGE = datetime.timedelta(days=7)
+
+    def test_fallback_hold_unknown_version(self):
+        result = minimum_age_reason_for_version(
+            "bash", "5.2-3", self.MIN_AGE, {},
+            MINIMUM_AGE_FALLBACK_HOLD, now=self.NOW, minimum_age_label="7d")
+        self.assertIsNotNone(result)
+        self.assertIn("keeping back", result)
+
+    def test_fallback_install_unknown_version(self):
+        result = minimum_age_reason_for_version(
+            "bash", "5.2-3", self.MIN_AGE, {},
+            MINIMUM_AGE_FALLBACK_INSTALL, now=self.NOW,
+            minimum_age_label="7d")
+        self.assertIsNone(result)
+
+
+def _make_mock_pkg(name, version, origin_name="allowed-origin"):
+    """Build a mock package that looks upgradable from an allowed origin."""
+    origin = Mock()
+    origin.origin = origin_name
+    origin.trusted = True
+
+    candidate = Mock()
+    candidate.version = version
+    candidate.origins = [origin]
+    candidate.policy_priority = 500
+
+    installed = Mock()
+    installed.version = "0.0.1"
+    installed.policy_priority = 500
+    installed.origins = [origin]
+
+    pkg = Mock()
+    pkg.name = name
+    pkg.is_upgradable = True
+    pkg.is_installed = True
+    pkg.is_auto_installed = False
+    pkg.candidate = candidate
+    pkg.installed = installed
+    pkg.versions = [candidate]
+    return pkg
+
+
+def _make_mock_cache(pkgs, seen_versions, minimum_age_value,
+                     fallback=MINIMUM_AGE_FALLBACK_HOLD):
+    """Build a mock cache with MinimumAge attributes wired up."""
+    cache = Mock()
+    cache.__iter__ = Mock(return_value=iter(pkgs))
+    cache.get_changes = Mock(return_value=[])
+    cache.allowed_origins = ["o=allowed-origin"]
+    cache.blacklist = []
+    cache.whitelist = []
+    cache.strict_whitelist = False
+
+    if isinstance(minimum_age_value, str):
+        min_delta, min_label = parse_minimum_age_setting(minimum_age_value)
+    elif isinstance(minimum_age_value, int):
+        min_delta = datetime.timedelta(days=minimum_age_value)
+        min_label = "%dd" % minimum_age_value
+    else:
+        min_delta = minimum_age_value
+        min_label = "0d"
+
+    cache.minimum_age_delta = min_delta
+    cache.minimum_age_label = min_label
+    cache.minimum_age_days = int(min_delta.total_seconds() // (24 * 3600))
+    cache.seen_versions = seen_versions
+    cache.minimum_age_fallback = fallback
+
+    from unattended_upgrade import minimum_age_reason_for_version as fn
+    cache.minimum_age_reason = (
+        lambda pkg_name, version: fn(
+            pkg_name, version, cache.minimum_age_delta,
+            cache.seen_versions, cache.minimum_age_fallback,
+            minimum_age_label=cache.minimum_age_label))
+
+    return cache
+
+
+class TestCalculateUpgradablePkgsMinimumAge(unittest.TestCase):
+    """Integration: MinimumAge filtering inside calculate_upgradable_pkgs."""
+
+    @patch("unattended_upgrade.try_to_upgrade",
+           side_effect=lambda pkg, lst, cache: lst.append(pkg))
+    def test_too_young_pkg_is_skipped_days(self, _mock_try):
+        pkg = _make_mock_pkg("bash", "5.2-3")
+        seen = {"bash": {"5.2-3": "2099-01-13T00:00:00Z"}}
+        cache = _make_mock_cache([pkg], seen, minimum_age_value="7")
+        options = Mock()
+
+        with patch("unattended_upgrade.utcnow_without_microseconds") as mock_now:
+            mock_now.return_value = datetime.datetime(2099, 1, 15, 0, 0, 0)
+            result = calculate_upgradable_pkgs(cache, options)
+
+        self.assertEqual(result, [])
+        _mock_try.assert_not_called()
+
+    @patch("unattended_upgrade.try_to_upgrade",
+           side_effect=lambda pkg, lst, cache: lst.append(pkg))
+    def test_old_enough_pkg_passes_days(self, _mock_try):
+        pkg = _make_mock_pkg("bash", "5.2-3")
+        seen = {"bash": {"5.2-3": "2099-01-05T00:00:00Z"}}
+        cache = _make_mock_cache([pkg], seen, minimum_age_value="7d")
+        options = Mock()
+
+        with patch("unattended_upgrade.utcnow_without_microseconds") as mock_now:
+            mock_now.return_value = datetime.datetime(2099, 1, 15, 0, 0, 0)
+            result = calculate_upgradable_pkgs(cache, options)
+
+        self.assertEqual(result, [pkg])
+        _mock_try.assert_called_once()
+
+    @patch("unattended_upgrade.try_to_upgrade",
+           side_effect=lambda pkg, lst, cache: lst.append(pkg))
+    def test_too_young_pkg_is_skipped_hours(self, _mock_try):
+        pkg = _make_mock_pkg("bash", "5.2-3")
+        seen = {"bash": {"5.2-3": "2099-01-15T00:00:00Z"}}
+        cache = _make_mock_cache([pkg], seen, minimum_age_value="24h")
+        options = Mock()
+
+        with patch("unattended_upgrade.utcnow_without_microseconds") as mock_now:
+            mock_now.return_value = datetime.datetime(2099, 1, 15, 23, 0, 0)
+            result = calculate_upgradable_pkgs(cache, options)
+
+        self.assertEqual(result, [])
+        _mock_try.assert_not_called()
+
+    @patch("unattended_upgrade.try_to_upgrade",
+           side_effect=lambda pkg, lst, cache: lst.append(pkg))
+    def test_minimum_age_zero_lets_everything_through(self, _mock_try):
+        pkg = _make_mock_pkg("bash", "5.2-3")
+        cache = _make_mock_cache([pkg], {}, minimum_age_value="0")
+        options = Mock()
+
+        result = calculate_upgradable_pkgs(cache, options)
+
+        self.assertEqual(result, [pkg])
+        _mock_try.assert_called_once()
+
+    @patch("unattended_upgrade.try_to_upgrade",
+           side_effect=lambda pkg, lst, cache: lst.append(pkg))
+    def test_fallback_hold_blocks_unknown(self, _mock_try):
+        pkg = _make_mock_pkg("bash", "5.2-3")
+        cache = _make_mock_cache([pkg], {}, minimum_age_value="7d",
+                                 fallback=MINIMUM_AGE_FALLBACK_HOLD)
+        options = Mock()
+
+        result = calculate_upgradable_pkgs(cache, options)
+
+        self.assertEqual(result, [])
+        _mock_try.assert_not_called()
+
+    @patch("unattended_upgrade.try_to_upgrade",
+           side_effect=lambda pkg, lst, cache: lst.append(pkg))
+    def test_fallback_install_passes_unknown(self, _mock_try):
+        pkg = _make_mock_pkg("bash", "5.2-3")
+        cache = _make_mock_cache([pkg], {}, minimum_age_value="7d",
+                                 fallback=MINIMUM_AGE_FALLBACK_INSTALL)
+        options = Mock()
+
+        result = calculate_upgradable_pkgs(cache, options)
+
+        self.assertEqual(result, [pkg])
+        _mock_try.assert_called_once()
+
+
+class TestMinimumAgeRealAptroot(TestBase):
+    """Integration tests using a real apt cache (root.rewind aptroot)."""
+
+    UPGRADABLE = ["test-package", "test2-package", "test3-package"]
+    FIXED_NOW = datetime.datetime(2099, 1, 15, 0, 0, 0)
+
+    def _make_cache(self):
+        self.mock_allowed_origins("origin=Ubuntu,archive=lucid-security")
+        rootdir = self.make_fake_aptroot(
+            os.path.join(self.testdir, "root.rewind"))
+        cache = unattended_upgrade.UnattendedUpgradesCache(rootdir=rootdir)
+        return rootdir, cache
+
+    def test_baseline_no_minimum_age(self):
+        rootdir, cache = self._make_cache()
+        self.assertEqual(cache.minimum_age_delta, datetime.timedelta(0))
+
+        options = MockOptions()
+        pkgs = calculate_upgradable_pkgs(cache, options)
+        self.assertEqual([p.name for p in pkgs], self.UPGRADABLE)
+
+    def test_minimum_age_blocks_fresh_packages(self):
+        apt_pkg.config.set("Unattended-Upgrade::MinimumAge", "7")
+        self.addCleanup(
+            apt_pkg.config.set, "Unattended-Upgrade::MinimumAge", "0")
+        rootdir, cache = self._make_cache()
+        self.assertEqual(cache.minimum_age_label, "7d")
+
+        seen_file = os.path.join(rootdir, SEEN_VERSIONS_FILE)
+        cache.seen_versions = record_seen_versions(
+            cache, seen_file, now=self.FIXED_NOW)
+
+        self.assertTrue(os.path.exists(seen_file))
+        loaded = load_seen_versions(seen_file)
+        for pkg_name in self.UPGRADABLE:
+            self.assertIn(pkg_name, loaded)
+            self.assertIn("2.0", loaded[pkg_name])
+
+        options = MockOptions()
+        with patch("unattended_upgrade.utcnow_without_microseconds") as mock_now:
+            mock_now.return_value = self.FIXED_NOW
+            pkgs = calculate_upgradable_pkgs(cache, options)
+        self.assertEqual(pkgs, [])
+
+    def test_minimum_age_passes_old_packages(self):
+        apt_pkg.config.set("Unattended-Upgrade::MinimumAge", "7")
+        self.addCleanup(
+            apt_pkg.config.set, "Unattended-Upgrade::MinimumAge", "0")
+        rootdir, cache = self._make_cache()
+
+        ten_days_ago = (self.FIXED_NOW - datetime.timedelta(days=10)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ")
+        seen = {}
+        for pkg_name in self.UPGRADABLE:
+            seen[pkg_name] = {"2.0": ten_days_ago}
+        seen_file = os.path.join(rootdir, SEEN_VERSIONS_FILE)
+        save_seen_versions(seen_file, seen)
+
+        cache.seen_versions = record_seen_versions(
+            cache, seen_file, now=self.FIXED_NOW)
+
+        options = MockOptions()
+        with patch("unattended_upgrade.utcnow_without_microseconds") as mock_now:
+            mock_now.return_value = self.FIXED_NOW
+            pkgs = calculate_upgradable_pkgs(cache, options)
+        self.assertEqual([p.name for p in pkgs], self.UPGRADABLE)
+
+    def test_minimum_age_hours_blocks_23h_and_allows_24h(self):
+        apt_pkg.config.set("Unattended-Upgrade::MinimumAge", "24h")
+        self.addCleanup(
+            apt_pkg.config.set, "Unattended-Upgrade::MinimumAge", "0")
+        rootdir, cache = self._make_cache()
+        self.assertEqual(cache.minimum_age_label, "24h")
+
+        seen_file = os.path.join(rootdir, SEEN_VERSIONS_FILE)
+        initial_seen = {}
+        for pkg_name in self.UPGRADABLE:
+            initial_seen[pkg_name] = {"2.0": "2099-01-15T00:00:00Z"}
+        save_seen_versions(seen_file, initial_seen)
+        cache.seen_versions = load_seen_versions(seen_file)
+
+        options = MockOptions()
+        with patch("unattended_upgrade.utcnow_without_microseconds") as mock_now:
+            mock_now.return_value = datetime.datetime(2099, 1, 15, 23, 0, 0)
+            pkgs_23h = calculate_upgradable_pkgs(cache, options)
+        self.assertEqual(pkgs_23h, [])
+
+        with patch("unattended_upgrade.utcnow_without_microseconds") as mock_now:
+            mock_now.return_value = datetime.datetime(2099, 1, 16, 0, 0, 0)
+            pkgs_24h = calculate_upgradable_pkgs(cache, options)
+        self.assertEqual([p.name for p in pkgs_24h], self.UPGRADABLE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_minimum_age.py
+++ b/test/test_minimum_age.py
@@ -223,7 +223,8 @@ class TestFallbackPolicy(unittest.TestCase):
         self.assertIsNone(result)
 
 
-def _make_mock_pkg(name, version, origin_name="allowed-origin"):
+def _make_mock_pkg(name, version, origin_name="allowed-origin",
+                   installed_version="0.0.1"):
     """Build a mock package that looks upgradable from an allowed origin."""
     origin = Mock()
     origin.origin = origin_name
@@ -235,7 +236,7 @@ def _make_mock_pkg(name, version, origin_name="allowed-origin"):
     candidate.policy_priority = 500
 
     installed = Mock()
-    installed.version = "0.0.1"
+    installed.version = installed_version
     installed.policy_priority = 500
     installed.origins = [origin]
 
@@ -371,6 +372,40 @@ class TestCalculateUpgradablePkgsMinimumAge(unittest.TestCase):
 
         self.assertEqual(result, [pkg])
         _mock_try.assert_called_once()
+
+
+class TestSkipInstalledCandidate(unittest.TestCase):
+    """Packages where allowed-origin candidate == installed should be skipped."""
+
+    def test_record_seen_versions_skips_installed_version(self):
+        """If the best version from allowed origins is already installed,
+        record_seen_versions must not add it to seen_versions."""
+        pkg = _make_mock_pkg("linux-firmware", "1.40",
+                             installed_version="1.40")
+        cache = _make_mock_cache([pkg], {}, minimum_age_value="7d")
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir)
+        state_file = os.path.join(tmpdir, "seen.json")
+
+        now = datetime.datetime(2099, 1, 15, 0, 0, 0)
+        seen = record_seen_versions(cache, state_file, now=now)
+        self.assertNotIn("linux-firmware", seen)
+
+    @patch("unattended_upgrade.try_to_upgrade",
+           side_effect=lambda pkg, lst, cache: lst.append(pkg))
+    def test_calculate_upgradable_skips_installed_candidate(self, _mock_try):
+        """If allowed-origin candidate == installed, the package must not
+        reach try_to_upgrade or appear in the result list."""
+        pkg = _make_mock_pkg("linux-firmware", "1.40",
+                             installed_version="1.40")
+        seen = {"linux-firmware": {"1.40": "2099-01-01T00:00:00Z"}}
+        cache = _make_mock_cache([pkg], seen, minimum_age_value="7d")
+        options = Mock()
+
+        result = calculate_upgradable_pkgs(cache, options)
+
+        self.assertEqual(result, [])
+        _mock_try.assert_not_called()
 
 
 class TestMinimumAgeRealAptroot(TestBase):

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -558,6 +558,9 @@ def record_seen_versions(cache, state_file_path, now=None, today=None):
             ver = ver_in_allowed_origin(pkg, cache.allowed_origins)
         except NoAllowedOriginError:
             continue
+        # Skip if the allowed-origin candidate is already installed
+        if pkg.is_installed and pkg.installed and ver.version == pkg.installed.version:
+            continue
         current_candidates[pkg.name] = ver.version
 
     # Add new entries
@@ -2252,6 +2255,9 @@ def calculate_upgradable_pkgs(cache,            # type: UnattendedUpgradesCache
                 candidate = ver_in_allowed_origin(
                     pkg, cache.allowed_origins)
             except NoAllowedOriginError:
+                continue
+            # Skip if the allowed-origin candidate is already installed
+            if pkg.is_installed and pkg.installed and candidate.version == pkg.installed.version:
                 continue
             reason = cache.minimum_age_reason(
                 pkg.name, candidate.version)

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -42,6 +42,7 @@ except ImportError:
 import grp
 import inspect
 import io
+import json
 from importlib.abc import Loader
 import importlib.util
 import locale
@@ -56,6 +57,7 @@ import string
 import subprocess
 import sys
 import syslog
+import tempfile
 
 try:
     from typing import AbstractSet, cast, DefaultDict, Dict, Iterable, List
@@ -107,6 +109,9 @@ if not sys.warnoptions:
 # the reboot required flag file used by packages
 REBOOT_REQUIRED_FILE = "/var/run/reboot-required"
 KEPT_PACKAGES_FILE = "var/lib/unattended-upgrades/kept-back"
+SEEN_VERSIONS_FILE = "var/lib/unattended-upgrades/seen-versions.json"
+MINIMUM_AGE_FALLBACK_INSTALL = "install"
+MINIMUM_AGE_FALLBACK_HOLD = "hold"
 MAIL_BINARY = "/usr/bin/mail"
 SENDMAIL_BINARY = "/usr/sbin/sendmail"
 USERS = "/usr/bin/users"
@@ -349,6 +354,236 @@ class PluginManager:
         self._call_plugin_func(func_name, result)
 
 
+def load_seen_versions(state_file_path):
+    # type: (str) -> Dict[str, Dict[str, str]]
+    """Load seen-versions state from JSON file.
+
+    Returns a dict mapping package names to {version: first_seen_timestamp}.
+    Returns {} on missing file, corrupt JSON, or format mismatch.
+    """
+    try:
+        with open(state_file_path, "r") as fp:
+            data = json.load(fp)
+    except (OSError, ValueError) as e:
+        if not (isinstance(e, OSError) and e.errno == errno.ENOENT):
+            logging.warning("Could not load seen-versions state %s: %s",
+                            state_file_path, e)
+        return {}
+    if not isinstance(data, dict) or data.get("_format_version") != 1:
+        logging.warning("Unsupported seen-versions format in %s, resetting",
+                        state_file_path)
+        return {}
+    return data.get("packages", {})
+
+
+def save_seen_versions(state_file_path, packages_dict):
+    # type: (str, Dict[str, Dict[str, str]]) -> None
+    """Atomically save seen-versions state to JSON file."""
+    data = {
+        "_format_version": 1,
+        "packages": packages_dict,
+    }
+    dir_path = os.path.dirname(state_file_path)
+    try:
+        os.makedirs(dir_path, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as fp:
+                json.dump(data, fp, indent=2, sort_keys=True)
+            os.rename(tmp_path, state_file_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+    except OSError as e:
+        logging.warning("Could not save seen-versions state %s: %s",
+                        state_file_path, e)
+
+
+def parse_minimum_age_setting(value):
+    # type: (str) -> Tuple[datetime.timedelta, str]
+    """Parse MinimumAge config value.
+
+    Supported forms:
+      - "7"   (days by default)
+      - "7d"  (days)
+      - "12h" (hours)
+    Returns (required_age_delta, normalized_setting_label).
+    """
+    normalized = (value or "").strip().lower()
+    if not normalized:
+        return datetime.timedelta(0), "0d"
+
+    match = re.match(r"^(\d+)([dh]?)$", normalized)
+    if match is None:
+        logging.warning(
+            "Invalid Unattended-Upgrade::MinimumAge value '%s', disabling",
+            value)
+        return datetime.timedelta(0), "0d"
+
+    amount = int(match.group(1))
+    unit = match.group(2) or "d"
+    if unit == "h":
+        return datetime.timedelta(hours=amount), "%dh" % amount
+    return datetime.timedelta(days=amount), "%dd" % amount
+
+
+def utcnow_without_microseconds():
+    # type: () -> datetime.datetime
+    """Return current UTC time as naive datetime without microseconds."""
+    return datetime.datetime.now(
+        datetime.timezone.utc).replace(tzinfo=None, microsecond=0)
+
+
+def first_seen_age_delta(pkg_name, version_str, seen_versions,
+                         now=None):
+    # type: (str, str, Dict[str, Dict[str, str]], Optional[datetime.datetime]) -> \
+    #       Optional[datetime.timedelta]
+    """Return the elapsed time since (pkg_name, version_str) was first seen.
+
+    Returns None if the package/version is not recorded.
+    """
+    pkg_versions = seen_versions.get(pkg_name)
+    if pkg_versions is None:
+        return None
+    first_seen_str = pkg_versions.get(version_str)
+    if first_seen_str is None:
+        return None
+    if now is None:
+        now = utcnow_without_microseconds()
+    try:
+        first_seen = datetime.datetime.strptime(
+            first_seen_str, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        logging.warning("Invalid timestamp '%s' for %s %s, treating as unknown",
+                        first_seen_str, pkg_name, version_str)
+        return None
+    return max(datetime.timedelta(0), now - first_seen)
+
+
+def first_seen_age_days(pkg_name, version_str, seen_versions, today=None):
+    # type: (str, str, Dict[str, Dict[str, str]], Optional[datetime.date]) -> \
+    #       Optional[int]
+    """Return the number of days since (pkg_name, version_str) was first seen.
+
+    Returns None if the package/version is not recorded.
+    """
+    if today is None:
+        now = None
+    else:
+        now = datetime.datetime.combine(today, datetime.time())
+    age_delta = first_seen_age_delta(
+        pkg_name, version_str, seen_versions, now=now)
+    if age_delta is None:
+        return None
+    return int(age_delta.total_seconds() // (24 * 3600))
+
+
+def minimum_age_reason_for_version(pkg_name, version, minimum_age,
+                                   seen_versions, fallback, now=None,
+                                   minimum_age_label=None, today=None):
+    # type: (str, str, Union[int, datetime.timedelta], Dict[str, Dict[str, str]], str,
+    #       Optional[datetime.datetime], Optional[str], Optional[datetime.date]) -> Optional[str]
+    """Check if a package version meets the MinimumAge requirement.
+
+    Returns a reason string if the package should be held back, None otherwise.
+    """
+    if today is not None and now is None:
+        now = datetime.datetime.combine(today, datetime.time())
+    if now is None:
+        now = utcnow_without_microseconds()
+
+    if isinstance(minimum_age, int):
+        minimum_age_delta = datetime.timedelta(days=max(0, minimum_age))
+        if minimum_age_label is None:
+            minimum_age_label = "%dd" % max(0, minimum_age)
+    else:
+        minimum_age_delta = minimum_age
+        if minimum_age_label is None:
+            minimum_age_label = "%dd" % int(
+                minimum_age_delta.total_seconds() // (24 * 3600))
+
+    if minimum_age_delta <= datetime.timedelta(0):
+        return None
+    age_delta = first_seen_age_delta(pkg_name, version, seen_versions, now=now)
+    if age_delta is None:
+        if fallback == MINIMUM_AGE_FALLBACK_INSTALL:
+            logging.warning(
+                "MinimumAge: no first-seen record for %s %s, "
+                "installing anyway (fallback=install)", pkg_name, version)
+            return None
+        else:
+            # fallback == "hold": treat as age 0
+            age_delta = datetime.timedelta(0)
+    if age_delta < minimum_age_delta:
+        unit = "h" if minimum_age_label.endswith("h") else "d"
+        if unit == "h":
+            age_value = int(age_delta.total_seconds() // 3600)
+            req_value = int(minimum_age_delta.total_seconds() // 3600)
+            unit_word = "hour(s)"
+        else:
+            age_value = int(age_delta.total_seconds() // (24 * 3600))
+            req_value = int(minimum_age_delta.total_seconds() // (24 * 3600))
+            unit_word = "day(s)"
+        return (
+            _("%(pkg)s %(ver)s is only %(age)d %(unit_word)s old"
+              " (MinimumAge: %(req)d%(unit)s), keeping back")
+            % {"pkg": pkg_name, "ver": version,
+               "age": age_value, "unit_word": unit_word,
+               "req": req_value, "unit": unit})
+    return None
+
+
+def record_seen_versions(cache, state_file_path, now=None, today=None):
+    # type: (UnattendedUpgradesCache, str, Optional[datetime.datetime], Optional[datetime.date]) -> \
+    #       Dict[str, Dict[str, str]]
+    """Record newly seen package versions and prune stale entries.
+
+    Returns the updated seen_versions dict.
+    """
+    seen_versions = load_seen_versions(state_file_path)
+    if now is None:
+        if today is not None:
+            now = datetime.datetime.combine(today, datetime.time())
+        else:
+            now = utcnow_without_microseconds()
+    now_str = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Collect current upgrade candidates: {pkg_name: version_str}
+    current_candidates = {}  # type: Dict[str, str]
+    for pkg in cache:
+        if not (pkg.is_upgradable or candidate_version_changed(pkg)):
+            continue
+        try:
+            ver = ver_in_allowed_origin(pkg, cache.allowed_origins)
+        except NoAllowedOriginError:
+            continue
+        current_candidates[pkg.name] = ver.version
+
+    # Add new entries
+    for pkg_name, version_str in current_candidates.items():
+        if pkg_name not in seen_versions:
+            seen_versions[pkg_name] = {}
+        if version_str not in seen_versions[pkg_name]:
+            seen_versions[pkg_name][version_str] = now_str
+            logging.debug("MinimumAge: first seen %s %s on %s",
+                          pkg_name, version_str, now_str)
+
+    # Prune: remove entries not in current candidates
+    for pkg_name in list(seen_versions.keys()):
+        if pkg_name not in current_candidates:
+            del seen_versions[pkg_name]
+        else:
+            for ver_str in list(seen_versions[pkg_name].keys()):
+                if ver_str != current_candidates[pkg_name]:
+                    del seen_versions[pkg_name][ver_str]
+            if not seen_versions[pkg_name]:
+                del seen_versions[pkg_name]
+
+    save_seen_versions(state_file_path, seen_versions)
+    return seen_versions
+
+
 class UnattendedUpgradesCache(apt.Cache):
 
     def __init__(self, rootdir):
@@ -386,6 +621,36 @@ class UnattendedUpgradesCache(apt.Cache):
         if self.running_kernel_pkgs_regexp:
             logging.debug("Using %s regexp to find running kernel packages",
                           self.running_kernel_pkgs_regexp.pattern)
+
+        minimum_age_value = apt_pkg.config.find(
+            "Unattended-Upgrade::MinimumAge", "0")
+        self.minimum_age_delta, self.minimum_age_label = (
+            parse_minimum_age_setting(minimum_age_value))
+        # Backward-compatible attribute used by existing code/tests.
+        self.minimum_age_days = int(
+            self.minimum_age_delta.total_seconds() // (24 * 3600))
+
+        self.minimum_age_fallback = apt_pkg.config.find(
+            "Unattended-Upgrade::MinimumAge-Fallback", "hold").lower()
+        if self.minimum_age_fallback not in (
+                MINIMUM_AGE_FALLBACK_INSTALL, MINIMUM_AGE_FALLBACK_HOLD):
+            logging.warning(
+                "Unknown MinimumAge-Fallback value '%s', using 'hold'",
+                self.minimum_age_fallback)
+            self.minimum_age_fallback = MINIMUM_AGE_FALLBACK_HOLD
+
+        self.seen_versions = {}  # type: Dict[str, Dict[str, str]]
+
+        if self.minimum_age_delta > datetime.timedelta(0):
+            logging.info("MinimumAge is %s, fallback policy is '%s'",
+                         self.minimum_age_label, self.minimum_age_fallback)
+
+    def minimum_age_reason(self, pkg_name, version):
+        # type: (str, str) -> Optional[str]
+        return minimum_age_reason_for_version(
+            pkg_name, version, self.minimum_age_delta,
+            self.seen_versions, self.minimum_age_fallback,
+            minimum_age_label=self.minimum_age_label)
 
     def find_better_version(self, pkg):
         # type (apt.Package) -> apt.package.Version
@@ -446,6 +711,9 @@ class UnattendedUpgradesCache(apt.Cache):
                             % pkg.name)
         elif not any([o.trusted for o in better_version.origins]):
             return _("Package %s's origin is not trusted.") % pkg.name
+        reason = self.minimum_age_reason(pkg.name, better_version.version)
+        if reason:
+            return reason
         return (_("Package %s is kept back because a related package"
                   " is kept back or due to local apt_preferences(5).")
                 % pkg.name)
@@ -1981,8 +2249,14 @@ def calculate_upgradable_pkgs(cache,            # type: UnattendedUpgradesCache
         if (pkg.is_upgradable or candidate_version_changed(pkg)
            and is_pkgname_in_whitelist(pkg.name, cache.whitelist)):
             try:
-                ver_in_allowed_origin(pkg, cache.allowed_origins)
+                candidate = ver_in_allowed_origin(
+                    pkg, cache.allowed_origins)
             except NoAllowedOriginError:
+                continue
+            reason = cache.minimum_age_reason(
+                pkg.name, candidate.version)
+            if reason:
+                logging.info(reason)
                 continue
             try_to_upgrade(pkg,
                            pkgs_to_upgrade,
@@ -2401,6 +2675,10 @@ def run(options,             # type: Options
         logging.error(_("Cache has broken packages, exiting"))
         return UnattendedUpgradesResult(
             False, _("Cache has broken packages, exiting"))
+
+    if cache.minimum_age_delta > datetime.timedelta(0):
+        seen_file = os.path.join(rootdir, SEEN_VERSIONS_FILE)
+        cache.seen_versions = record_seen_versions(cache, seen_file)
 
     with try_nice(20):
         auto_removable = get_auto_removable(cache)


### PR DESCRIPTION
This addresses the use case from #339 and helps improve production stability by adding a configurable rollout delay (for example, 7 days) before automatic installation.

Implements persistent seen-version state

On each run, unattended-upgrades updates this state, records new candidate versions with the current date, and prunes stale entries. MinimumAge is then evaluated against this stored first-seen date.
