### PR TITLE
Fix transitive dependency accumulator reuse

### DIFF
--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import Mock
+
+from unattended_upgrade import transitive_dependencies
+
+
+class TestDependencies(unittest.TestCase):
+
+    def _get_pkg_with_deps(self, *dep_names):
+        pkg = Mock()
+        pkg.candidate = Mock()
+        pkg.candidate.dependencies = [
+            [Mock(name=name, rawtype="Depends")] for name in dep_names]
+        for dep, dep_name in zip(pkg.candidate.dependencies, dep_names):
+            dep[0].name = dep_name
+        return pkg
+
+    def test_transitive_dependencies_keeps_independent_calls_separate(self):
+        cache = {}
+        first_pkg = self._get_pkg_with_deps("first-dependency")
+        second_pkg = self._get_pkg_with_deps("second-dependency")
+
+        self.assertEqual(
+            {"first-dependency"}, transitive_dependencies(first_pkg, cache))
+        self.assertEqual(
+            {"second-dependency"}, transitive_dependencies(second_pkg, cache))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1265,7 +1265,7 @@ def is_pkg_change_allowed(pkg, blacklist, whitelist, strict_whitelist):
 
 def transitive_dependencies(pkg,               # type: apt.Package
                             cache,             # type: apt.Cache
-                            acc=set(),         # type AbstractSet[str]
+                            acc=None,          # type: Optional[Set[str]]
                             valid_types=None,  # type: Optional[AbstractSet[str]]
                             level=None         # type: Optional[int]
                             ):
@@ -1274,6 +1274,9 @@ def transitive_dependencies(pkg,               # type: apt.Package
 
         Note that alternative (|) dependencies are collected, too
     """
+    if acc is None:
+        acc = set()
+
     if not pkg.candidate or level is not None and level < 1:
         return acc
 


### PR DESCRIPTION
## Summary

- avoid reusing one mutable dependency accumulator across independent transitive dependency walks
- add a focused regression test that calls `transitive_dependencies()` twice with different package dependency sets

## Tests

- `PYTHONPATH=. python3 -m unittest test.test_dependencies test.test_rewind test.test_unavailable_candidate`
