### PR TITLE
log: fix `auto-removed` and `kept back` log in normal mode

### DIFF
--- a/test/test_remove_unused.py
+++ b/test/test_remove_unused.py
@@ -67,12 +67,11 @@ Auto-Installed: 1
             ["rm", "-f",
              os.path.join(self.rootdir, "var", "cache", "apt", "*.bin")])
 
-    def test_remove_unused_dependencies(self):
+    def _remove_unused_dependencies(self, minimal_steps):
         apt.apt_pkg.config.clear("APT::VersionedKernelPackages")
         apt_conf = os.path.join(self.rootdir, "etc", "apt", "apt.conf")
         with open(apt_conf, "w") as fp:
             fp.write("""
-Unattended-Upgrade::MinimalSteps "false";
 Unattended-Upgrade::Keep-Debs-After-Install "true";
 Unattended-Upgrade::Allowed-Origins {
     "Ubuntu:lucid-security";
@@ -81,6 +80,7 @@ Unattended-Upgrade::Remove-Unused-Dependencies "true";
 Unattended-Upgrade::Skip-Updates-On-Metered-Connections "false";
 """)
         options = MockOptions()
+        options.minimal_upgrade_steps = minimal_steps
         unattended_upgrade.main(options, rootdir=self.rootdir)
         with open(self.log) as f:
             # both the new and the old unused dependency are removed
@@ -90,6 +90,14 @@ Unattended-Upgrade::Skip-Updates-On-Metered-Connections "false";
             haystack = f.read()
             self.assertTrue(needle in haystack,
                             "Can not find '%s' in '%s'" % (needle, haystack))
+
+    def test_remove_unused_dependencies_minimal_steps(self):
+        self._remove_unused_dependencies(minimal_steps=True)
+
+    def test_remove_unused_dependencies_single_step(self):
+        # GH: #396 - the auto-removed packages were missing from the log
+        # when not minimizing the upgrade steps
+        self._remove_unused_dependencies(minimal_steps=False)
 
     def test_remove_unused_dependencies_new_unused_only(self):
         apt.apt_pkg.config.set("APT::VersionedKernelPackages::", "linux-image")

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -2178,10 +2178,17 @@ def do_auto_remove(cache,             # type: UnattendedUpgradesCache
         if is_autoremove_valid(cache, "", auto_removable):
             # do it in one step
             if not dry_run:
+                changes = cache.get_changes()
+                pkgnames = {pkg.name for pkg in changes}
                 res, error = cache_commit(cache, logfile_dpkg, verbose)
+                if res:
+                    pkgs_removed.extend(pkgnames)
             else:
                 cache.clear()
         else:
+            # removing the auto-removable packages would also remove
+            # packages that are not set for removal, so keep them installed
+            pkgs_kept_installed = list(auto_removable)
             cache.clear()
 
     if res:

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -2133,6 +2133,26 @@ def is_autoremove_valid(cache,           # type: UnattendedUpgradesCache
     return True
 
 
+def _commit_auto_removals(cache,         # type: UnattendedUpgradesCache
+                          logfile_dpkg,  # type: str
+                          verbose,       # type: bool
+                          dry_run        # type: bool
+                          ):
+    # type: (...) -> Tuple[bool, str, List[str]]
+    """Commit the pending removals marked in the cache.
+
+    Returns a (success, error, pkgs_removed) tuple where pkgs_removed
+    holds the names of the packages that were actually removed (empty on
+    a dry-run or a failed commit).
+    """
+    if dry_run:
+        cache.clear()
+        return (True, "", [])
+    pkgnames = [pkg.name for pkg in cache.get_changes()]
+    res, error = cache_commit(cache, logfile_dpkg, verbose)
+    return (res, error, pkgnames if res else [])
+
+
 def do_auto_remove(cache,             # type: UnattendedUpgradesCache
                    auto_removable,    # type: AbstractSet[str]
                    logfile_dpkg,      # type: str
@@ -2142,6 +2162,7 @@ def do_auto_remove(cache,             # type: UnattendedUpgradesCache
                    ):
     # type: (...) -> Tuple[bool, List[str], List[str]]
     res = True
+    error = "unset"
     if not auto_removable:
         return (res, [], [])
 
@@ -2163,28 +2184,19 @@ def do_auto_remove(cache,             # type: UnattendedUpgradesCache
                 pkgs_kept_installed.append(pkgname)
                 cache.clear()
                 continue
-            if not dry_run:
-                changes = cache.get_changes()
-                pkgnames = {pkg.name for pkg in changes}
-                res, error = cache_commit(cache, logfile_dpkg, verbose)
-                if not res:
-                    break
-                pkgs_removed.extend(pkgnames)
-            else:
-                cache.clear()
+            res, error, removed = _commit_auto_removals(
+                cache, logfile_dpkg, verbose, dry_run)
+            if not res:
+                break
+            pkgs_removed.extend(removed)
     else:
         for pkgname in auto_removable:
             cache[pkgname].mark_delete()
         if is_autoremove_valid(cache, "", auto_removable):
             # do it in one step
-            if not dry_run:
-                changes = cache.get_changes()
-                pkgnames = {pkg.name for pkg in changes}
-                res, error = cache_commit(cache, logfile_dpkg, verbose)
-                if res:
-                    pkgs_removed.extend(pkgnames)
-            else:
-                cache.clear()
+            res, error, removed = _commit_auto_removals(
+                cache, logfile_dpkg, verbose, dry_run)
+            pkgs_removed.extend(removed)
         else:
             # removing the auto-removable packages would also remove
             # packages that are not set for removal, so keep them installed


### PR DESCRIPTION
When not in minimal-steps mode the logs do not report the
`auto-removed` and `kept back` packages. This is a regression
from commit 07e27ac - this commit fixes the issue again.

Thanks to @ov2k for reporting this. Closes #396.

