### PR TITLE
kernel: update KERNEL_VERSION_REGEXP for newer trixie kernels

### DIFF
--- a/test/autopkgtest_kernel_patterns.py
+++ b/test/autopkgtest_kernel_patterns.py
@@ -6,7 +6,8 @@ import re
 import subprocess
 import unittest
 
-from unattended_upgrade import (running_kernel_pkgs_regexp,
+from unattended_upgrade import (KERNEL_VERSION_REGEXP,
+                                running_kernel_pkgs_regexp,
                                 versioned_kernel_pkgs_regexp)
 
 
@@ -21,7 +22,7 @@ class TestKernelPatterns(unittest.TestCase):
         running_escaped_regexp = ".*" + re.escape(running_kernel_version) + '$'
         try:
             running_noflavor_regexp = "linux.*-" + re.escape(
-                re.match("[1-9][0-9]*\\.[0-9]+\\.[0-9]+-[0-9]+",
+                re.match(KERNEL_VERSION_REGEXP,
                          running_kernel_version)[0])
         except TypeError:
             self.skipTest("Could not find flavor of running kernel. It may "

--- a/test/test_kernel_pattern.py
+++ b/test/test_kernel_pattern.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+
+import re
+import unittest
+
+import apt_pkg
+
+from unattended_upgrade import (KERNEL_VERSION_REGEXP,
+                                versioned_kernel_pkgs_regexp)
+
+
+class TestKernelPattern(unittest.TestCase):
+
+    def setUp(self):
+        apt_pkg.init_config()
+        apt_pkg.config.clear("APT::VersionedKernelPackages")
+        for p in ("linux-image", "linux-headers", "linux-image-extra",
+                  "linux-modules", "linux-modules-extra"):
+            apt_pkg.config.set("APT::VersionedKernelPackages::", p)
+
+    # package names that must be recognized as versioned kernel packages
+    SHOULD_MATCH = [
+        # classic Debian "X.Y.Z-<ABI>-<flavour>"
+        "linux-image-6.1.0-9-amd64",
+        # Ubuntu "X.Y.Z-<ABI>-<flavour>"
+        "linux-image-5.15.0-1021-kvm",
+        # Debian trixie+ "X.Y.Z+debN-<flavour>" (GH #395)
+        "linux-image-6.12.88+deb13-amd64",
+        "linux-image-6.12.90+deb13-amd64",
+        "linux-image-6.12.90+deb13.1-amd64",
+        "linux-image-6.12.74+deb13+1-arm64",
+        # ... including the assorted flavours/variants
+        "linux-image-6.12.90+deb13-cloud-amd64",
+        "linux-image-6.12.90+deb13-rt-amd64",
+        "linux-image-6.12.90+deb13.1-amd64-unsigned",
+        "linux-image-6.12.73+deb13-arm64-16k",
+        "linux-headers-6.12.90+deb13-amd64",
+        "linux-modules-6.12.90+deb13-amd64",
+    ]
+
+    # package names that must NOT be treated as versioned kernel packages
+    SHOULD_NOT_MATCH = [
+        "linux-image-amd64",
+        "linux-image-arm64",
+        "linux-image-cloud-amd64",
+        "linux-image-rt-amd64",
+        "linux-image-generic",
+        "linux-headers-amd64",
+    ]
+
+    def test_versioned_kernel_pkgs_regexp(self):
+        regexp = versioned_kernel_pkgs_regexp()
+        for name in self.SHOULD_MATCH:
+            self.assertTrue(regexp.match(name),
+                            "%s should match %s" % (name, regexp.pattern))
+        for name in self.SHOULD_NOT_MATCH:
+            self.assertFalse(regexp.match(name),
+                             "%s should not match %s" % (name, regexp.pattern))
+
+    def test_kernel_version_regexp_strips_flavour(self):
+        # KERNEL_VERSION_REGEXP is used to derive the flavour-independent
+        # version from "uname -r" for the running-kernel protection
+        cases = {
+            "6.1.0-9-amd64": "6.1.0-9",
+            "5.15.0-1021-kvm": "5.15.0-1021",
+            "6.12.90+deb13-amd64": "6.12.90+deb13",
+            "6.12.90+deb13.1-amd64": "6.12.90+deb13.1",
+            "6.12.74+deb13+1-rt-amd64": "6.12.74+deb13+1",
+        }
+        for uname, expected in cases.items():
+            match = re.match(KERNEL_VERSION_REGEXP, uname)
+            self.assertIsNotNone(match, "no version found in %s" % uname)
+            self.assertEqual(match[0], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_remove_unused_kernel.py
+++ b/test/test_remove_unused_kernel.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import unittest
+
+import apt
+
+from test.test_base import TestBase, MockOptions
+import unattended_upgrade
+
+apt.apt_pkg.config.set("APT::Architecture", "amd64")
+
+
+class TestRemoveUnusedKernel(TestBase):
+    """Regression test for GH #395.
+
+    Debian trixie+ kernels carry the Debian revision in the package name
+    (e.g. linux-image-6.12.90+deb13-amd64).  Make sure such an auto-removable
+    kernel is recognized as a versioned kernel package and handled through the
+    dedicated kernel-removal path instead of slipping through unclassified.
+    """
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.rootdir = self.make_fake_aptroot(
+            template=os.path.join(self.testdir, "root.unused-deps"),
+            fake_pkgs=[
+                # the two newest kernels are kept by apt's kernel protection
+                ("linux-image-6.12.91+deb13-amd64", "6.12.91", {}),
+                ("linux-image-6.12.90+deb13-amd64", "6.12.90", {}),
+                # the oldest, auto-installed and now unused kernel -> removable
+                ("linux-image-6.12.88+deb13-amd64", "6.12.88", {}),
+            ]
+        )
+        # FIXME: make this more elegant
+        # fake on_ac_power
+        os.environ["PATH"] = (os.path.join(self.rootdir, "usr", "bin") + ":"
+                              + os.environ["PATH"])
+        # pretend the old kernel was pulled in automatically
+        extended_states = os.path.join(
+            self.rootdir, "var", "lib", "apt", "extended_states")
+        with open(extended_states, "w") as f:
+            f.write("""
+Package: linux-image-6.12.88+deb13-amd64
+Architecture: all
+Auto-Installed: 1
+""")
+        # clean log
+        self.log = os.path.join(
+            self.rootdir, "var", "log", "unattended-upgrades",
+            "unattended-upgrades.log")
+        if not os.path.exists(os.path.dirname(self.log)):
+            os.makedirs(os.path.dirname(self.log))
+        with open(self.log, "w"):
+            pass
+        # clean cache
+        subprocess.check_call(
+            ["rm", "-f",
+             os.path.join(self.rootdir, "var", "cache", "apt", "*.bin")])
+
+    def test_remove_unused_debian_versioned_kernel(self):
+        apt.apt_pkg.config.clear("APT::VersionedKernelPackages")
+        apt.apt_pkg.config.set("APT::VersionedKernelPackages::", "linux-image")
+        apt_conf = os.path.join(self.rootdir, "etc", "apt", "apt.conf")
+        with open(apt_conf, "w") as fp:
+            fp.write("""
+Unattended-Upgrade::Keep-Debs-After-Install "true";
+Unattended-Upgrade::Allowed-Origins {
+    "Ubuntu:lucid-security";
+};
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Skip-Updates-On-Metered-Connections "false";
+""")
+        options = MockOptions()
+        unattended_upgrade.main(options, rootdir=self.rootdir)
+        with open(self.log) as f:
+            haystack = f.read()
+        # the +deb13 kernel must be recognized as a kernel package and removed
+        # through the dedicated kernel-removal path (before the GH #395 fix it
+        # was not matched by the versioned-kernel regexp at all)
+        needle = "Removing unused kernel packages: "\
+                 "linux-image-6.12.88+deb13-amd64\n"
+        self.assertIn(needle, haystack,
+                      "Can not find '%s' in '%s'" % (needle, haystack))
+        # the newest kernel must not be removed
+        self.assertNotIn("linux-image-6.12.90+deb13-amd64", haystack.replace(
+            needle, ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -942,12 +942,22 @@ def allow_marking_fallback():
         get_distro_codename() != "sid")
 
 
+# The version part of a versioned kernel package name (or of "uname -r"),
+# i.e. everything up to but excluding the trailing "-<flavour>".  It is the
+# upstream "X.Y.Z" followed by either the classic "-<ABI>" number used by
+# Debian/Ubuntu (e.g. linux-image-6.1.0-9-amd64, linux-image-5.15.0-1021-kvm)
+# or the Debian revision baked into the package name of newer (trixie+)
+# kernels (e.g. linux-image-6.12.90+deb13.1-amd64, +deb13, +deb13+1). See #395.
+KERNEL_VERSION_REGEXP = ("[1-9][0-9]*\\.[0-9]+\\.[0-9]+"
+                         "(-[0-9]+|\\+deb[0-9]+(\\.[0-9]+|\\+[0-9]+)?)")
+
+
 def versioned_kernel_pkgs_regexp():
     apt_versioned_kernel_pkgs = apt_pkg.config.value_list(
         "APT::VersionedKernelPackages")
     if apt_versioned_kernel_pkgs:
         return re.compile("(" + "|".join(
-            ["^" + p + "-[1-9][0-9]*\\.[0-9]+\\.[0-9]+-[0-9]+(-.+)?$"
+            ["^" + p + "-" + KERNEL_VERSION_REGEXP + "(-.+)?$"
              for p in apt_versioned_kernel_pkgs]) + ")")
     else:
         return None
@@ -962,7 +972,7 @@ def running_kernel_pkgs_regexp():
         kernel_escaped = re.escape(running_kernel_version)
         try:
             kernel_noflavor_escaped = re.escape(
-                re.match("[1-9][0-9]*\\.[0-9]+\\.[0-9]+-[0-9]+",
+                re.match(KERNEL_VERSION_REGEXP,
                          running_kernel_version)[0])
             return re.compile("(" + "|".join(
                 [("^" + p + "-" + kernel_escaped + "$|^"


### PR DESCRIPTION
The kernel regex does no longer match the new kernels from trixie, e.g. `linux-image-6.12.74+deb13+1-arm64`.

This commit updates the regex and adds a regressions test.

Thanks to @ov2k for reporting this. Closes: #395