### PR TITLE
data: tweak logrotate config to use copytruncate

### DIFF
--- a/data/logrotate.d/unattended-upgrades
+++ b/data/logrotate.d/unattended-upgrades
@@ -4,6 +4,10 @@
 {
   rotate 6
   monthly
+  # unattended-upgrades keeps the log file open while running so there
+  # is a race here when rotating mid-run. copytruncate keeps the original
+  # fd open so u-u can keep writing
+  copytruncate
   compress
   missingok
   notifempty


### PR DESCRIPTION
There is a race when u-u run and logrotate also runs at the same time. Logrotate would then rename/compress the log file that u-u writes to and then deletes the file so parts of the logs are lost.

The easiest fix is to just use "copytruncate" in logrotate, this way the log is copied and then original log truncated but because its the same FD u-u can keep writing. Not ideal as there is might be a weird split in the logs now but better than losing data.

Thanks to @drzraf. Closes: #389