### PR TITLE
debian: use os-release, drop lsb-release dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,6 @@ Depends: ${misc:Depends},
          python3-dbus,
          python3-distro-info,
          ucf,
-         lsb-release,
          lsb-base,
          xz-utils
 Recommends: systemd-sysv | cron | cron-daemon | anacron

--- a/debian/postinst
+++ b/debian/postinst
@@ -37,6 +37,21 @@ uu_running() {
     python3 -c 'import apt; import apt_pkg; import sys; sys.exit(1 if apt_pkg.get_lock("/var/run/unattended-upgrades.lock") >= 0 else 0)'
 }
 
+# Return the (lower-case) distribution ID from os-release(5), e.g. "debian"
+# or "ubuntu". Read directly instead of via lsb_release(1) so we do not
+# depend on the lsb-release package. Sourced in a subshell so the os-release
+# variables do not leak into this script. See os-release(5).
+distro_id() {
+    (
+        if [ -e /etc/os-release ]; then
+            . /etc/os-release
+        elif [ -e /usr/lib/os-release ]; then
+            . /usr/lib/os-release
+        fi
+        printf '%s\n' "${ID:-}"
+    ) 2>/dev/null
+}
+
 case "$1" in
     configure)
 	# *sigh* typo in filename in version 0.51ubuntu1
@@ -72,11 +87,11 @@ case "$1" in
 	ucfr unattended-upgrades "$CONFIG"
 
         # Recover from broken dh_installinit override in versions < 0.93.1+nmu1 (or < 0.93.1ubuntu3 in Ubuntu)
-        if ([ "$(lsb_release -i -s)" != "Ubuntu" ] \
+        if ([ "$(distro_id)" != "ubuntu" ] \
                 && ( dpkg --compare-versions "$2" lt "0.93.1+nmu1" \
                          || (dpkg --compare-versions "$2" ge "1.5~" \
                                  && dpkg --compare-versions "$2" lt "1.7~" ) ) ) || \
-               ([ "$(lsb_release -i -s)" = "Ubuntu" ] \
+               ([ "$(distro_id)" = "ubuntu" ] \
                     && ( dpkg --compare-versions "$2" lt "0.93.1ubuntu3" \
                              || (dpkg --compare-versions "$2" ge "1.5ubuntu1~" \
                                      && dpkg --compare-versions "$2" lt "1.5ubuntu4~" ) \
@@ -118,11 +133,11 @@ esac
 # sees the service as disable and will not enable it.
 case "$1" in
     configure)
-        if ( ([ "$(lsb_release -i -s)" != "Ubuntu" ] \
+        if ( ([ "$(distro_id)" != "ubuntu" ] \
                   && ( dpkg --compare-versions "$2" lt "0.93.1+nmu1" \
                            || (dpkg --compare-versions "$2" ge "1.5~" \
                                    && dpkg --compare-versions "$2" lt "1.7~" ) ) ) || \
-                 ([ "$(lsb_release -i -s)" = "Ubuntu" ] \
+                 ([ "$(distro_id)" = "ubuntu" ] \
                       && ( dpkg --compare-versions "$2" lt "0.93.1ubuntu3" \
                                || (dpkg --compare-versions "$2" ge "1.5ubuntu1~" \
                                        && dpkg --compare-versions "$2" lt "1.5ubuntu4~" ) \

--- a/test/test_os_release.py
+++ b/test/test_os_release.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import unattended_upgrade
+
+
+class TestOsRelease(unittest.TestCase):
+
+    def tearDown(self):
+        # restore the real (host) distro info that may have been overridden
+        unattended_upgrade.init_distro_info()
+
+    def _init_from(self, content):
+        with tempfile.NamedTemporaryFile(
+                "w", suffix="os-release", delete=False) as f:
+            f.write(content)
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        unattended_upgrade.init_distro_info(paths=[path])
+
+    def test_parse_debian_stable(self):
+        self._init_from(
+            'PRETTY_NAME="Debian GNU/Linux 13 (trixie)"\n'
+            'NAME="Debian GNU/Linux"\n'
+            'VERSION_ID="13"\n'
+            'VERSION="13 (trixie)"\n'
+            'VERSION_CODENAME=trixie\n'
+            'ID=debian\n')
+        self.assertEqual(unattended_upgrade.DISTRO_ID, "Debian")
+        self.assertEqual(unattended_upgrade.DISTRO_CODENAME, "trixie")
+        self.assertEqual(unattended_upgrade.DISTRO_RELEASE, "13")
+        self.assertEqual(unattended_upgrade.DISTRO_DESC,
+                         "Debian GNU/Linux 13 (trixie)")
+
+    def test_parse_ubuntu(self):
+        # ID is lower case in os-release but lsb_release reports "Ubuntu";
+        # the NAME field carries the canonical casing
+        self._init_from(
+            'PRETTY_NAME="Ubuntu 24.04.3 LTS"\n'
+            'NAME="Ubuntu"\n'
+            'VERSION_ID="24.04"\n'
+            'VERSION_CODENAME=noble\n'
+            'ID=ubuntu\n'
+            'UBUNTU_CODENAME=noble\n')
+        self.assertEqual(unattended_upgrade.DISTRO_ID, "Ubuntu")
+        self.assertEqual(unattended_upgrade.DISTRO_CODENAME, "noble")
+        self.assertEqual(unattended_upgrade.DISTRO_RELEASE, "24.04")
+
+    def test_parse_missing_fields_fall_back_to_na(self):
+        # Debian testing/sid has no VERSION_CODENAME / VERSION_ID, matching
+        # the "n/a" that lsb_release emits in that case
+        self._init_from(
+            'PRETTY_NAME="Debian GNU/Linux trixie/sid"\n'
+            'NAME="Debian GNU/Linux"\n'
+            'ID=debian\n')
+        self.assertEqual(unattended_upgrade.DISTRO_ID, "Debian")
+        self.assertEqual(unattended_upgrade.DISTRO_CODENAME, "n/a")
+        self.assertEqual(unattended_upgrade.DISTRO_RELEASE, "n/a")
+
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(
+            unattended_upgrade.parse_os_release(paths=["/does/not/exist"]), {})
+
+    @unittest.skipUnless(shutil.which("lsb_release"),
+                         "lsb_release not installed")
+    def test_matches_lsb_release(self):
+        """our os-release parsing must produce the same values lsb_release
+        derives from os-release on this system"""
+        unattended_upgrade.init_distro_info()
+
+        def lsb(flag):
+            return subprocess.check_output(
+                ["lsb_release", flag, "-s"], universal_newlines=True).strip()
+
+        self.assertEqual(unattended_upgrade.DISTRO_ID, lsb("-i"))
+        self.assertEqual(unattended_upgrade.DISTRO_CODENAME, lsb("-c"))
+        self.assertEqual(unattended_upgrade.DISTRO_RELEASE, lsb("-r"))
+        self.assertEqual(unattended_upgrade.DISTRO_DESC, lsb("-d"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -51,6 +51,7 @@ import re
 import os
 import pwd
 import select
+import shlex
 import signal
 import socket
 import string
@@ -113,23 +114,62 @@ SENDMAIL_BINARY = "/usr/sbin/sendmail"
 USERS = "/usr/bin/users"
 
 
-# no py3 lsb_release in debian :/
 DISTRO_CODENAME = ""  # type: str
 DISTRO_DESC = ""  # type: str
 DISTRO_ID = ""  # type: str
 DISTRO_RELEASE = ""  # type: str
 
+OS_RELEASE_PATHS = ["/etc/os-release", "/usr/lib/os-release"]
 
-def init_distro_info():
+
+def parse_os_release(paths=None):
+    # type: (Optional[List[str]]) -> Dict[str, str]
+    """Parse the first available os-release(5) file into a dict.
+
+    This is the same data lsb_release(1) reports on modern systems, so we
+    read it directly and avoid spawning lsb_release (and depending on the
+    lsb-release package being installed at all).
+    """
+    # TODO: replace with platform.freedesktop_os_release() once the minimum
+    # Python is >= 3.10 (Bullseye is still on 3.9, Bionic on 3.6)
+    data = {}  # type: Dict[str, str]
+    for path in (paths or OS_RELEASE_PATHS):
+        try:
+            f = open(path)
+        except FileNotFoundError:
+            continue
+        with f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                # values may be shell-quoted, see os-release(5)
+                try:
+                    tokens = shlex.split(value)
+                except ValueError:
+                    tokens = [value.strip("\"'")]
+                data[key.strip()] = tokens[0] if tokens else ""
+        break
+    return data
+
+
+def init_distro_info(paths=None):
+    # type: (Optional[List[str]]) -> None
     global DISTRO_CODENAME, DISTRO_DESC, DISTRO_ID, DISTRO_RELEASE
-    DISTRO_CODENAME = subprocess.check_output(
-        ["lsb_release", "-c", "-s"], universal_newlines=True).strip()
-    DISTRO_DESC = subprocess.check_output(
-        ["lsb_release", "-d", "-s"], universal_newlines=True).strip()
-    DISTRO_ID = subprocess.check_output(
-        ["lsb_release", "-i", "-s"], universal_newlines=True).strip()
-    DISTRO_RELEASE = subprocess.check_output(
-        ["lsb_release", "-r", "-s"], universal_newlines=True).strip()
+    os_release = parse_os_release(paths)
+    # mimic the values lsb_release(1) derives from os-release
+    distro_id = os_release.get("ID", "")
+    # capitalize the first letter (e.g. "ubuntu" -> "Ubuntu")
+    distro_id = distro_id[:1].upper() + distro_id[1:]
+    # use NAME if it only differs from ID in capitalization
+    name = os_release.get("NAME", "")
+    if name and distro_id.lower() == name.lower():
+        distro_id = name
+    DISTRO_ID = distro_id or "n/a"
+    DISTRO_DESC = os_release.get("PRETTY_NAME", "n/a")
+    DISTRO_RELEASE = os_release.get("VERSION_ID", "n/a")
+    DISTRO_CODENAME = os_release.get("VERSION_CODENAME", "n/a")
 
 
 # init global distro info


### PR DESCRIPTION
[draft as it needs #400 first]

This commit switches to parse /etc/os-release for the lsb-release
information. This means we can drop the lsb-release dependency
and avoid the multile forks when getting the DISTRO_ID and friends.
