### PR TITLE
u-u: avoid hangs on big upgrade calculations

### DIFF
--- a/test/test_origin_pattern.py
+++ b/test/test_origin_pattern.py
@@ -40,6 +40,9 @@ class MockCache(dict):
     def get_changes(self):
         for pkgname in self.keys():
             yield self[pkgname]
+
+    def is_in_allowed_origin_cached(self, ver):
+        return is_in_allowed_origin(ver, self.allowed_origins)
     allowed_origins = []  # type: List[str]
     blacklist = []        # type: List[str]
     whitelist = []        # type: List[str]

--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -26,6 +26,29 @@ class TestRewindCache(TestBase):
         unattended_upgrade.rewind_cache(self.cache, to_upgrade)
         self.assertEqual(self.cache['test-package'].candidate.version, "2.0")
 
+    def test_rewind_cache_uses_fast_path(self):
+        """ rewind uses the cheap mark_install path when it is sufficient """
+        options = MockOptions()
+        options.try_run = True
+        to_upgrade = unattended_upgrade.calculate_upgradable_pkgs(
+            self.cache, options)
+        # spy on the expensive adjusted path to prove it is not used
+        adjusted_calls = []
+        orig_mark_install_adjusted = self.cache.mark_install_adjusted
+
+        def spy(pkg, **kwargs):
+            adjusted_calls.append(pkg.name)
+            return orig_mark_install_adjusted(pkg, **kwargs)
+        self.cache.mark_install_adjusted = spy
+
+        unattended_upgrade.rewind_cache(self.cache, to_upgrade)
+
+        self.assertEqual(adjusted_calls, [])
+        self.assertEqual(self.cache['test-package'].candidate.version, "2.0")
+        self.assertEqual(self.cache.broken_count, 0)
+        for pkg in to_upgrade:
+            self.assertTrue(pkg.marked_install or pkg.marked_upgrade)
+
 
 if __name__ == "__main__":
     import logging

--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -49,6 +49,17 @@ class TestRewindCache(TestBase):
         for pkg in to_upgrade:
             self.assertTrue(pkg.marked_install or pkg.marked_upgrade)
 
+    def test_calculate_upgradable_pkgs_stops_on_signal(self):
+        """ a stop signal aborts the package check at the next save point """
+        options = MockOptions()
+        options.try_run = True
+        self.addCleanup(
+            setattr, unattended_upgrade, "SIGNAL_STOP_REQUEST", False)
+        unattended_upgrade.SIGNAL_STOP_REQUEST = True
+        to_upgrade = unattended_upgrade.calculate_upgradable_pkgs(
+            self.cache, options)
+        self.assertEqual(to_upgrade, [])
+
 
 if __name__ == "__main__":
     import logging

--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -49,6 +49,19 @@ class TestRewindCache(TestBase):
         for pkg in to_upgrade:
             self.assertTrue(pkg.marked_install or pkg.marked_upgrade)
 
+    def test_is_in_allowed_origin_cached(self):
+        """ the memoized origin check matches the uncached one and caches """
+        pkg = self.cache["test-package"]
+        ver = pkg.candidate
+        expected = unattended_upgrade.is_in_allowed_origin(
+            ver, self.cache.allowed_origins)
+        self.assertEqual(self.cache.is_in_allowed_origin_cached(ver), expected)
+        self.assertIn((ver.package.name, ver.version),
+                      self.cache._in_allowed_origin_memo)
+        # second call returns the same cached result
+        self.assertEqual(self.cache.is_in_allowed_origin_cached(ver), expected)
+        self.assertFalse(self.cache.is_in_allowed_origin_cached(None))
+
     def test_calculate_upgradable_pkgs_stops_on_signal(self):
         """ a stop signal aborts the package check at the next save point """
         options = MockOptions()

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -358,6 +358,11 @@ class UnattendedUpgradesCache(apt.Cache):
     def __init__(self, rootdir):
         # type: (str) -> None
         self._cached_candidate_pkgnames = set()  # type: Set[str]
+        # remember the version adjust_candidate() resolved for a package so we
+        # can re-apply it cheaply after a cache.clear() instead of recomputing
+        # ver_in_allowed_origin(); the result is deterministic for a run
+        self._resolved_candidate_versions = \
+            {}  # type: Dict[str, apt.package.Version]
 
         self.allowed_origins = get_allowed_origins()
         logging.info(_("Allowed origins are: %s"),
@@ -557,6 +562,7 @@ class UnattendedUpgradesCache(apt.Cache):
                     "adjusting candidate to version %s in allowed "
                     "origin %s" % (new_cand, new_cand.origins))
                 pkg.candidate = new_cand
+                self._resolved_candidate_versions[pkg.name] = new_cand
                 return True
             else:
                 return False
@@ -607,9 +613,13 @@ class UnattendedUpgradesCache(apt.Cache):
             logging.debug("falling back to adjusting %s's dependencies"
                           % pkg.name)
             self.clear()
-            # adjust candidates in advance if needed
+            # re-apply candidates adjusted earlier; cache.clear() reset them
+            # but ver_in_allowed_origin() is deterministic so we can restore
+            # the recorded version instead of recomputing it
             for pkg_name in self._cached_candidate_pkgnames:
-                self.adjust_candidate(self[pkg_name])
+                ver = self._resolved_candidate_versions.get(pkg_name)
+                if ver is not None and self[pkg_name].candidate != ver:
+                    self[pkg_name].candidate = ver
 
             self.adjust_candidate(pkg)
             for dep in transitive_dependencies(pkg, self, level=1):

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -2074,6 +2074,11 @@ def calculate_upgradable_pkgs(cache,            # type: UnattendedUpgradesCache
 
     # now do the actual upgrade
     for pkg in cache:
+        # check the signal directly rather than should_stop() which spawns
+        # on_ac_power per call, too expensive in this per-package loop
+        if SIGNAL_STOP_REQUEST:
+            logging.warning(_("SIGNAL received, stopping package check"))
+            break
         if options.debug and pkg.is_upgradable \
            or candidate_version_changed(pkg):
             logging.debug("Checking: %s (%s)" % (

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -1345,9 +1345,12 @@ def check_changes_for_sanity(cache, desired_pkg=None):
     if sanity_check_result is None:
         return True
     else:
-        logging.debug("sanity check failed for: %s : %s"
-                      % (str({str(p.candidate) for p in cache.get_changes()}),
-                         sanity_check_result))
+        # the change set behind a failed check can be hundreds of
+        # packages: so only show the number and the failed pkg
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            num_changes = sum(1 for _ in cache.get_changes())
+            logging.debug("sanity check failed for %d package(s): %s",
+                          num_changes, sanity_check_result)
         return False
 
 

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -363,6 +363,9 @@ class UnattendedUpgradesCache(apt.Cache):
         # ver_in_allowed_origin(); the result is deterministic for a run
         self._resolved_candidate_versions = \
             {}  # type: Dict[str, apt.package.Version]
+        # memoize is_in_allowed_origin() results; a version's origins and the
+        # allowed_origins list are both constant for a run
+        self._in_allowed_origin_memo = {}  # type: Dict[Tuple[str, str], bool]
 
         self.allowed_origins = get_allowed_origins()
         logging.info(_("Allowed origins are: %s"),
@@ -405,7 +408,7 @@ class UnattendedUpgradesCache(apt.Cache):
             for v in pkg.versions:
                 if pkg.installed < v \
                    and pkg.installed.policy_priority <= v.policy_priority \
-                   and is_in_allowed_origin(v, self.allowed_origins):
+                   and self.is_in_allowed_origin_cached(v):
                     return v
         return None
 
@@ -582,6 +585,21 @@ class UnattendedUpgradesCache(apt.Cache):
             if self[pkg_name].candidate != ver:
                 self[pkg_name].candidate = ver
 
+    def is_in_allowed_origin_cached(self, ver):
+        # type: (Optional[apt.package.Version]) -> bool
+        """ memoized is_in_allowed_origin(); the result depends only on the
+            version (its origins are fixed) and allowed_origins, both constant
+            for a run, so it is safe to cache by (package name, version)
+        """
+        if ver is None:
+            return False
+        key = (ver.package.name, ver.version)
+        cached = self._in_allowed_origin_memo.get(key)
+        if cached is None:
+            cached = is_in_allowed_origin(ver, self.allowed_origins)
+            self._in_allowed_origin_memo[key] = cached
+        return cached
+
     def call_checked(self, function, pkg, **kwargs):
         """ Call function and check if package is in the wanted state
         """
@@ -641,8 +659,7 @@ class UnattendedUpgradesCache(apt.Cache):
         for marked_pkg in self.get_changes():
             if marked_pkg.name in self._cached_candidate_pkgnames:
                 continue
-            if not is_in_allowed_origin(marked_pkg.candidate,
-                                        self.allowed_origins):
+            if not self.is_in_allowed_origin_cached(marked_pkg.candidate):
                 try:
                     ver_in_allowed_origin(marked_pkg,
                                           self.allowed_origins)
@@ -1372,7 +1389,7 @@ def sanity_problem(cache, desired_pkg):
             # origin so its good enough if we have a single trusted one
             if not any([o.trusted for o in pkg.candidate.origins]):
                 return ("pkg %s is not from a trusted origin" % pkg.name)
-            if not is_in_allowed_origin(pkg.candidate, cache.allowed_origins):
+            if not cache.is_in_allowed_origin_cached(pkg.candidate):
                 return ("pkg %s is not in an allowed origin" % pkg.name)
             if not is_pkg_change_allowed(pkg,
                                          cache.blacklist,

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -569,6 +569,19 @@ class UnattendedUpgradesCache(apt.Cache):
         except NoAllowedOriginError:
             return False
 
+    def restore_adjusted_candidates(self):
+        # type: () -> None
+        """ re-apply the candidate versions resolved by adjust_candidate()
+
+            cache.clear() resets candidates to their defaults, so they have to
+            be restored before re-marking against the previously resolved
+            state. ver_in_allowed_origin() is deterministic for a run, so
+            re-applying the recorded version is equivalent to recomputing it.
+        """
+        for pkg_name, ver in self._resolved_candidate_versions.items():
+            if self[pkg_name].candidate != ver:
+                self[pkg_name].candidate = ver
+
     def call_checked(self, function, pkg, **kwargs):
         """ Call function and check if package is in the wanted state
         """
@@ -613,13 +626,8 @@ class UnattendedUpgradesCache(apt.Cache):
             logging.debug("falling back to adjusting %s's dependencies"
                           % pkg.name)
             self.clear()
-            # re-apply candidates adjusted earlier; cache.clear() reset them
-            # but ver_in_allowed_origin() is deterministic so we can restore
-            # the recorded version instead of recomputing it
-            for pkg_name in self._cached_candidate_pkgnames:
-                ver = self._resolved_candidate_versions.get(pkg_name)
-                if ver is not None and self[pkg_name].candidate != ver:
-                    self[pkg_name].candidate = ver
+            # cache.clear() reset the candidates adjusted earlier, restore them
+            self.restore_adjusted_candidates()
 
             self.adjust_candidate(pkg)
             for dep in transitive_dependencies(pkg, self, level=1):
@@ -1588,6 +1596,27 @@ def dpkg_conffile_prompt():
 def rewind_cache(cache, pkgs_to_upgrade):
     # type: (UnattendedUpgradesCache, List[apt.Package]) -> None
     """ set the cache back to the state with packages_to_upgrade """
+    cache.clear()
+    # Fast path: the candidate versions of these packages and their deps were
+    # already resolved by adjust_candidate() in an earlier pass. Restore them
+    # and do a plain mark_install to reproduce the previously-accepted set
+    # without re-running the expensive per-package adjust/fallback recursion.
+    # rewind_cache() is called once per package that fails the sanity check,
+    # so that recursion makes the naive approach O(n^2) in the number of
+    # upgradable packages, which can peg the CPU when many are held back.
+    cache.restore_adjusted_candidates()
+    try:
+        for pkg2 in pkgs_to_upgrade:
+            pkg2.mark_install(from_user=not pkg2.is_auto_installed)
+        if (
+            cache.broken_count == 0
+            and sanity_problem(cache, None) is None
+            and all(pkg2.marked_install or pkg2.marked_upgrade
+                    for pkg2 in pkgs_to_upgrade)):
+            return
+    except SystemError:
+        pass
+    # Slow but always-correct fallback
     cache.clear()
     for pkg2 in pkgs_to_upgrade:
         cache.mark_install_adjusted(pkg2, from_user=not pkg2.is_auto_installed)


### PR DESCRIPTION
This PR adds some changes to make the upgrade calculation faster and more responsive. 

Closes: https://github.com/mvo5/unattended-upgrades/issues/402 