### PR TITLE
core: stop the calculate_upgradable_pkgs on SIGNAL_STOP_REQUEST

### DIFF
--- a/test/test_rewind.py
+++ b/test/test_rewind.py
@@ -26,6 +26,17 @@ class TestRewindCache(TestBase):
         unattended_upgrade.rewind_cache(self.cache, to_upgrade)
         self.assertEqual(self.cache['test-package'].candidate.version, "2.0")
 
+    def test_calculate_upgradable_pkgs_stops_on_signal(self):
+        """ a stop signal aborts the package check at the next save point """
+        options = MockOptions()
+        options.try_run = True
+        self.addCleanup(
+            setattr, unattended_upgrade, "SIGNAL_STOP_REQUEST", False)
+        unattended_upgrade.SIGNAL_STOP_REQUEST = True
+        to_upgrade = unattended_upgrade.calculate_upgradable_pkgs(
+            self.cache, options)
+        self.assertEqual(to_upgrade, [])
+
 
 if __name__ == "__main__":
     import logging

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -2035,6 +2035,11 @@ def calculate_upgradable_pkgs(cache,            # type: UnattendedUpgradesCache
 
     # now do the actual upgrade
     for pkg in cache:
+        # check the signal directly rather than should_stop() which spawns
+        # on_ac_power per call, too expensive in this per-package loop
+        if SIGNAL_STOP_REQUEST:
+            logging.warning(_("SIGNAL received, stopping package check"))
+            break
         if options.debug and pkg.is_upgradable \
            or candidate_version_changed(pkg):
             logging.debug("Checking: %s (%s)" % (


### PR DESCRIPTION
This commit adds another stop point in the code. When the system shuts down we want to stop as soon as its safe. So when we are in calculate_upgradable_pkgs we now also check if we need to stop and exit. This should ensure that a shutdown is not blocked by a (potentially) slow calculation of an upgrade path.