### PR TITLE
u-u: fix mypy issue and fix CI to run it

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Build-Depends-Indep: python3-dev,
                      pycodestyle <!nocheck> | pep8 <!nocheck>,
 #                    powermgmt-base, (tests disable on_ac_power checks)
                      flake8 <!nocheck>,
+                     mypy <!nocheck>,
                      python3-apt (>= 1.9.6~),
                      lsb-release
 Standards-Version: 4.1.4

--- a/unattended-upgrade
+++ b/unattended-upgrade
@@ -2186,7 +2186,7 @@ def _commit_auto_removals(cache,         # type: UnattendedUpgradesCache
                           verbose,       # type: bool
                           dry_run        # type: bool
                           ):
-    # type: (...) -> Tuple[bool, str, List[str]]
+    # type: (...) -> Tuple[bool, Optional[Exception], List[str]]
     """Commit the pending removals marked in the cache.
 
     Returns a (success, error, pkgs_removed) tuple where pkgs_removed
@@ -2195,7 +2195,7 @@ def _commit_auto_removals(cache,         # type: UnattendedUpgradesCache
     """
     if dry_run:
         cache.clear()
-        return (True, "", [])
+        return (True, None, [])
     pkgnames = [pkg.name for pkg in cache.get_changes()]
     res, error = cache_commit(cache, logfile_dpkg, verbose)
     return (res, error, pkgnames if res else [])
@@ -2210,7 +2210,7 @@ def do_auto_remove(cache,             # type: UnattendedUpgradesCache
                    ):
     # type: (...) -> Tuple[bool, List[str], List[str]]
     res = True
-    error = "unset"
+    error = None  # type: Optional[Exception]
     if not auto_removable:
         return (res, [], [])
 


### PR DESCRIPTION
There was a missing mypy build-dependency and this lead the mypy tests to get skipped in CI. This is clearly not ideal so this commit fixes CI and the mypy type mismatches.